### PR TITLE
fix: CLI setup rerun

### DIFF
--- a/tools/cli/commands/setup.py
+++ b/tools/cli/commands/setup.py
@@ -844,9 +844,12 @@ def setup(
     else:
         click.echo("12/12: Skipped core services configuration.")
 
-    # restrict access to IaC remote state store
-    cloud_man.protect_iac_state_storage(p.internals["TF_BACKEND_STORAGE_NAME"],
-                                        p.parameters["<IAC_PR_AUTOMATION_IAM_ROLE_RN>"])
+    if not p.has_checkpoint("tf-store-hardening"):
+        # restrict access to IaC remote state store
+        cloud_man.protect_iac_state_storage(p.internals["TF_BACKEND_STORAGE_NAME"],
+                                            p.parameters["<IAC_PR_AUTOMATION_IAM_ROLE_RN>"])
+        p.set_checkpoint("tf-store-hardening")
+        p.save_checkpoint()
 
     show_credentials(p)
 


### PR DESCRIPTION
### Description of the Change
Fix error on re-run of setup command using Azure cloud provider caused by blob storage caused by blob storage access policy duplication, by moving  tf state store security hardening into separate step.