### PR TITLE
Fix: cli destroy incomplete setup

### DIFF
--- a/tools/cli/commands/workload/create.py
+++ b/tools/cli/commands/workload/create.py
@@ -1,6 +1,7 @@
 import time
 
 import click
+from git import InvalidGitRepositoryError
 
 from common.const.const import GITOPS_REPOSITORY_MAIN_BRANCH, WL_PR_BRANCH_NAME_PREFIX
 from common.custom_excpetions import GitBranchAlreadyExists, PullRequestCreationError
@@ -59,8 +60,10 @@ def create(wl_name: str, wl_repo_name: str, wl_gitops_repo_name: str, verbosity:
         wl_gitops_repo_name=wl_gitops_repo_name
     )
     click.echo("2/7: Workload names processed.")
-
-    git_man, gor = initialize_gitops_repository(state_store=state_store, logger=logger)
+    try:
+        git_man, gor = initialize_gitops_repository(state_store=state_store, logger=logger)
+    except InvalidGitRepositoryError:
+        raise click.ClickException("GitOps repo does not exist")
     click.echo("3/7: GitOps repository initialized.")
 
     try:

--- a/tools/cli/commands/workload/delete.py
+++ b/tools/cli/commands/workload/delete.py
@@ -3,6 +3,7 @@ import shutil
 import time
 
 import click
+from git import InvalidGitRepositoryError
 
 from common.const.common_path import LOCAL_WORKLOAD_TEMP_FOLDER
 from common.const.const import GITOPS_REPOSITORY_MAIN_BRANCH, WL_PR_BRANCH_NAME_PREFIX, WL_GITOPS_REPOSITORY_BRANCH, \
@@ -104,8 +105,10 @@ def delete(
         wl_gitops_repo_name=wl_gitops_repo_name,
     )
     click.echo(f"3/{logging_total_steps}: Workload names processed.")
-
-    git_man, gor = initialize_gitops_repository(state_store=state_store, logger=logger)
+    try:
+        git_man, gor = initialize_gitops_repository(state_store=state_store, logger=logger)
+    except InvalidGitRepositoryError:
+        raise click.ClickException("GitOps repo does not exist")
     click.echo(f"4/{logging_total_steps}: GitOps repository initialized.")
 
     try:

--- a/tools/cli/common/utils/command_utils.py
+++ b/tools/cli/common/utils/command_utils.py
@@ -157,9 +157,6 @@ def check_installation_presence():
     if not os.path.exists(LOCAL_FOLDER):
         raise click.ClickException("CG DevX metadata does not exist on this machine")
 
-    if not os.path.exists(LOCAL_GITOPS_FOLDER):
-        raise click.ClickException("GitOps repo does not exist")
-
 
 def initialize_gitops_repository(
         state_store: StateStore, logger: Logger
@@ -187,7 +184,8 @@ def initialize_gitops_repository(
         git_man=git_man,
         author_name=state_store.internals["GIT_USER_NAME"],
         author_email=state_store.internals["GIT_USER_EMAIL"],
-        key_path=state_store.internals["DEFAULT_SSH_PRIVATE_KEY_PATH"]
+        key_path=state_store.internals["DEFAULT_SSH_PRIVATE_KEY_PATH"],
+        repo_remote_url=state_store.parameters.get("<GIT_REPOSITORY_GIT_URL>")
     )
     gor.update()
     logger.info("GitOps repository initialized.")
@@ -255,7 +253,7 @@ def create_and_open_pull_request(
 def preprocess_workload_names(
         logger: Logger,
         wl_name: str, wl_repo_name: Optional[str] = None, wl_gitops_repo_name: Optional[str] = None
-                              ) -> tuple[str, str, str]:
+) -> tuple[str, str, str]:
     """
     Process and normalize workload names to a standard format.
 

--- a/tools/cli/services/tf_wrapper.py
+++ b/tools/cli/services/tf_wrapper.py
@@ -12,7 +12,7 @@ from common.logging_config import logger
 
 class TerraformExecutionError(Exception):
     def __init__(self, return_code: int, stdout: str, stderr: str):
-        super().__init__(f"Terraform command failed with return code {return_code} and error: {stderr}")
+        super().__init__(f"Terraform command failed with return code {return_code} and error: \"{stderr}\"")
         self.return_code = return_code
         self.stdout = stdout
         self.stderr = stderr
@@ -304,7 +304,7 @@ class TerraformCommandManager:
             return None
 
         # Communicate with the process to retrieve stderr and the return code
-        stderr, _ = target_process.communicate()
+        _, stderr = target_process.communicate()
         return_code = target_process.returncode
 
         # Reset an internal process if it was used


### PR DESCRIPTION
### Description of the Change

- **Fallback to Git Clone on Local GitOps Repo Initialization Failure**: In scenarios where local initialization of a GitOps repository fails, the system now automatically attempts to clone the repository from Git. This ensures continuity and reduces setup failures for users.
  
- **Enhanced Error Handling in Terraform Wrapper**: Corrected the error output mechanism within the Terraform wrapper. Errors are now more accurately displayed to the user, enhancing the clarity and immediacy of troubleshooting.

- **Avoiding Unnecessary Initialization**: The process has been refined to prevent the attempt to initialize a repository if certain prerequisites, such as the completion of the "gitops-vcs" step, are not met. This optimization prevents errors and inefficiencies in the setup process.
