### PR TITLE
fix: only namespaces in clusterResourceWhitelist for workload AppProject

### DIFF
--- a/platform/gitops-pipelines/delivery/clusters/cc-cluster/workloads/workload-template.yaml
+++ b/platform/gitops-pipelines/delivery/clusters/cc-cluster/workloads/workload-template.yaml
@@ -12,9 +12,10 @@ spec:
   destinations:
     - namespace: 'wl-<WL_NAME>-*'
       server: '*'
+  # Deny all cluster-scoped resources from being created, except for Namespace
   clusterResourceWhitelist:
     - group: '*'
-      kind: '*'
+      kind: Namespace
   roles:
     # A role which provides read-only access to all applications in the project
     - name: read-only


### PR DESCRIPTION
### Description of the Change

Deny all cluster-scoped resources from being created, except for Namespace
