### PR TITLE
argocd after-push sync webhook

### DIFF
--- a/platform/TEMPLATING.md
+++ b/platform/TEMPLATING.md
@@ -56,6 +56,7 @@ The following templating variables are generated during setup process:
 
 ### Git Configuration
 
+- `CD_PUSH_EVENT_WEBHOOK_SECRET` - Continuous Delivery (ArgoCD) push event automation webhook secret.
 - `GIT_REPOSITORY_GIT_URL` - Git URL for the Platform GitOps repository.
 - `GIT_REPOSITORY_ROOT` - Git organization root.
 - `GIT_REPOSITORY_URL` - HTTP URL for the Platform GitOps repository.

--- a/platform/gitops-pipelines/delivery/clusters/cc-cluster/core-services/components/argo-workflows/application.yaml
+++ b/platform/gitops-pipelines/delivery/clusters/cc-cluster/core-services/components/argo-workflows/application.yaml
@@ -22,6 +22,9 @@ spec:
         singleNamespace: false
         nameOverride: argo
         controller:
+          instanceID:
+            enabled: true
+            explicitID: "cgdevx"
           workflowDefaults:
             spec:
               podGC:

--- a/platform/gitops-pipelines/delivery/clusters/cc-cluster/core-services/components/argocd/argocd-secret.yaml
+++ b/platform/gitops-pipelines/delivery/clusters/cc-cluster/core-services/components/argocd/argocd-secret.yaml
@@ -3,4 +3,4 @@ kind: Secret
 metadata:
   name: argocd-secret
 stringData:
-  webhook.github.secret: $argocd-webhook-secret:cd_webhook_secret
+  webhook.<GIT_PROVIDER>.secret: $argocd-webhook-secret:cd_webhook_secret

--- a/platform/gitops-pipelines/delivery/clusters/cc-cluster/core-services/components/argocd/argocd-secret.yaml
+++ b/platform/gitops-pipelines/delivery/clusters/cc-cluster/core-services/components/argocd/argocd-secret.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: argocd-secret
+stringData:
+  webhook.github.secret: $argocd-webhook-secret:cd_webhook_secret

--- a/platform/gitops-pipelines/delivery/clusters/cc-cluster/core-services/components/argocd/externalsecrets.yaml
+++ b/platform/gitops-pipelines/delivery/clusters/cc-cluster/core-services/components/argocd/externalsecrets.yaml
@@ -1,9 +1,12 @@
+---
 apiVersion: "external-secrets.io/v1alpha1"
 kind: ExternalSecret
 metadata:
   name: argocd-oidc-secret
   labels:
     app.kubernetes.io/part-of: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: '-10'
 spec:
   target:
     name: argocd-oidc-secret
@@ -20,3 +23,24 @@ spec:
         key: oidc/argocd
         property: client_id
       secretKey: clientId
+---
+apiVersion: "external-secrets.io/v1alpha1"
+kind: ExternalSecret
+metadata:
+  name: argocd-webhook-secret
+  labels:
+    app.kubernetes.io/part-of: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: '-10'
+spec:
+  target:
+    name: argocd-webhook-secret
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: vault-kv-secret
+  refreshInterval: 10s
+  data:
+    - remoteRef:
+        key: cd-secrets
+        property: cd_webhook_secret
+      secretKey: cd_webhook_secret

--- a/platform/gitops-pipelines/delivery/clusters/cc-cluster/core-services/components/argocd/kustomization.yaml
+++ b/platform/gitops-pipelines/delivery/clusters/cc-cluster/core-services/components/argocd/kustomization.yaml
@@ -14,6 +14,7 @@ patches:
 - path: argocd-cm.yaml
 - path: argocd-cmd-params-cm.yaml
 - path: argocd-rbac-cm.yaml
+- path: argocd-secret.yaml
 
 generatorOptions:
   disableNameSuffixHash: true

--- a/platform/terraform/modules/secrets_vault/TERRAFORM-README.md
+++ b/platform/terraform/modules/secrets_vault/TERRAFORM-README.md
@@ -1,77 +1,92 @@
 <!-- BEGIN_TF_DOCS -->
-
 ## Requirements
 
-| Name                                                    | Version |
-|---------------------------------------------------------|---------|
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.47 |
+No requirements.
 
 ## Providers
 
-| Name                                                       | Version |
-|------------------------------------------------------------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws)          | >= 4.47 |
-| <a name="provider_random"></a> [random](#provider\_random) | n/a     |
-| <a name="provider_vault"></a> [vault](#provider\_vault)    | n/a     |
+| Name | Version |
+|------|---------|
+| <a name="provider_random"></a> [random](#provider\_random) | n/a |
+| <a name="provider_vault"></a> [vault](#provider\_vault) | n/a |
 
 ## Modules
 
-| Name                                                            | Source           | Version |
-|-----------------------------------------------------------------|------------------|---------|
-| <a name="module_argo"></a> [argo](#module\_argo)                | ./oidc-client    | n/a     |
-| <a name="module_argocd"></a> [argocd](#module\_argocd)          | ./oidc-client    | n/a     |
-| <a name="module_grafana"></a> [grafana](#module\_grafana)       | ./oidc-client    | n/a     |
-| <a name="module_harbor"></a> [harbor](#module\_harbor)          | ./oidc-client    | n/a     |
-| <a name="module_sonarqube"></a> [sonarqube](#module\_sonarqube) | ./oidc-client    | n/a     |
-| <a name="module_workloads"></a> [workloads](#module\_workloads) | ./vault-workload | n/a     |
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_argo"></a> [argo](#module\_argo) | ./oidc-client | n/a |
+| <a name="module_argocd"></a> [argocd](#module\_argocd) | ./oidc-client | n/a |
+| <a name="module_grafana"></a> [grafana](#module\_grafana) | ./oidc-client | n/a |
+| <a name="module_harbor"></a> [harbor](#module\_harbor) | ./oidc-client | n/a |
+| <a name="module_oauth2_backstage"></a> [oauth2\_backstage](#module\_oauth2\_backstage) | ./oidc-client | n/a |
+| <a name="module_sonarqube"></a> [sonarqube](#module\_sonarqube) | ./oidc-client | n/a |
+| <a name="module_workloads"></a> [workloads](#module\_workloads) | ./vault-workload | n/a |
 
 ## Resources
 
-| Name                                                                                                                                                                  | Type        |
-|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-| [random_password.atlantis_password](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password)                                          | resource    |
-| [random_password.grafana_password](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password)                                           | resource    |
-| [vault_auth_backend.k8s](https://registry.terraform.io/providers/hashicorp/vault/latest/docs/resources/auth_backend)                                                  | resource    |
-| [vault_auth_backend.userpass](https://registry.terraform.io/providers/hashicorp/vault/latest/docs/resources/auth_backend)                                             | resource    |
-| [vault_generic_secret.atlantis_auth_secrets](https://registry.terraform.io/providers/hashicorp/vault/latest/docs/resources/generic_secret)                            | resource    |
-| [vault_generic_secret.atlantis_secrets](https://registry.terraform.io/providers/hashicorp/vault/latest/docs/resources/generic_secret)                                 | resource    |
-| [vault_generic_secret.ci_secrets](https://registry.terraform.io/providers/hashicorp/vault/latest/docs/resources/generic_secret)                                       | resource    |
-| [vault_generic_secret.docker_config](https://registry.terraform.io/providers/hashicorp/vault/latest/docs/resources/generic_secret)                                    | resource    |
-| [vault_generic_secret.grafana_secrets](https://registry.terraform.io/providers/hashicorp/vault/latest/docs/resources/generic_secret)                                  | resource    |
-| [vault_generic_secret.registry_auth](https://registry.terraform.io/providers/hashicorp/vault/latest/docs/resources/generic_secret)                                    | resource    |
-| [vault_identity_group.admins](https://registry.terraform.io/providers/hashicorp/vault/latest/docs/resources/identity_group)                                           | resource    |
-| [vault_identity_group.developers](https://registry.terraform.io/providers/hashicorp/vault/latest/docs/resources/identity_group)                                       | resource    |
-| [vault_identity_oidc_key.key](https://registry.terraform.io/providers/hashicorp/vault/latest/docs/resources/identity_oidc_key)                                        | resource    |
-| [vault_identity_oidc_provider.cgdevx](https://registry.terraform.io/providers/hashicorp/vault/latest/docs/resources/identity_oidc_provider)                           | resource    |
-| [vault_identity_oidc_scope.email_scope](https://registry.terraform.io/providers/hashicorp/vault/latest/docs/resources/identity_oidc_scope)                            | resource    |
-| [vault_identity_oidc_scope.group_scope](https://registry.terraform.io/providers/hashicorp/vault/latest/docs/resources/identity_oidc_scope)                            | resource    |
-| [vault_identity_oidc_scope.profile_scope](https://registry.terraform.io/providers/hashicorp/vault/latest/docs/resources/identity_oidc_scope)                          | resource    |
-| [vault_identity_oidc_scope.user_scope](https://registry.terraform.io/providers/hashicorp/vault/latest/docs/resources/identity_oidc_scope)                             | resource    |
-| [vault_kubernetes_auth_backend_config.k8s](https://registry.terraform.io/providers/hashicorp/vault/latest/docs/resources/kubernetes_auth_backend_config)              | resource    |
-| [vault_kubernetes_auth_backend_role.k8s_atlantis](https://registry.terraform.io/providers/hashicorp/vault/latest/docs/resources/kubernetes_auth_backend_role)         | resource    |
-| [vault_kubernetes_auth_backend_role.k8s_external_secrets](https://registry.terraform.io/providers/hashicorp/vault/latest/docs/resources/kubernetes_auth_backend_role) | resource    |
-| [vault_mount.secret](https://registry.terraform.io/providers/hashicorp/vault/latest/docs/resources/mount)                                                             | resource    |
-| [vault_mount.users](https://registry.terraform.io/providers/hashicorp/vault/latest/docs/resources/mount)                                                              | resource    |
-| [vault_mount.workloads](https://registry.terraform.io/providers/hashicorp/vault/latest/docs/resources/mount)                                                          | resource    |
-| [vault_policy.admin](https://registry.terraform.io/providers/hashicorp/vault/latest/docs/resources/policy)                                                            | resource    |
-| [vault_policy.developer](https://registry.terraform.io/providers/hashicorp/vault/latest/docs/resources/policy)                                                        | resource    |
-| [aws_eks_cluster.cluster](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_cluster)                                                 | data source |
-| [aws_eks_cluster_auth.cluster](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_cluster_auth)                                       | data source |
+| Name | Type |
+|------|------|
+| [random_password.atlantis_password](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
+| [random_password.grafana_password](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
+| [random_password.harbor_main_robot_password](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
+| [random_password.harbor_password](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
+| [random_password.oauth2_backstage_cookie_password](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
+| [random_password.sonarqube_password](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
+| [vault_auth_backend.k8s](https://registry.terraform.io/providers/hashicorp/vault/latest/docs/resources/auth_backend) | resource |
+| [vault_auth_backend.userpass](https://registry.terraform.io/providers/hashicorp/vault/latest/docs/resources/auth_backend) | resource |
+| [vault_generic_secret.atlantis_auth_secrets](https://registry.terraform.io/providers/hashicorp/vault/latest/docs/resources/generic_secret) | resource |
+| [vault_generic_secret.atlantis_secrets](https://registry.terraform.io/providers/hashicorp/vault/latest/docs/resources/generic_secret) | resource |
+| [vault_generic_secret.ci_secrets](https://registry.terraform.io/providers/hashicorp/vault/latest/docs/resources/generic_secret) | resource |
+| [vault_generic_secret.docker_config](https://registry.terraform.io/providers/hashicorp/vault/latest/docs/resources/generic_secret) | resource |
+| [vault_generic_secret.grafana_secrets](https://registry.terraform.io/providers/hashicorp/vault/latest/docs/resources/generic_secret) | resource |
+| [vault_generic_secret.harbor_admin_secret](https://registry.terraform.io/providers/hashicorp/vault/latest/docs/resources/generic_secret) | resource |
+| [vault_generic_secret.harbor_main_robot_secret](https://registry.terraform.io/providers/hashicorp/vault/latest/docs/resources/generic_secret) | resource |
+| [vault_generic_secret.oauth2_cookie_secret](https://registry.terraform.io/providers/hashicorp/vault/latest/docs/resources/generic_secret) | resource |
+| [vault_generic_secret.registry_auth](https://registry.terraform.io/providers/hashicorp/vault/latest/docs/resources/generic_secret) | resource |
+| [vault_generic_secret.sonarqube_admin_secret](https://registry.terraform.io/providers/hashicorp/vault/latest/docs/resources/generic_secret) | resource |
+| [vault_identity_group.admins](https://registry.terraform.io/providers/hashicorp/vault/latest/docs/resources/identity_group) | resource |
+| [vault_identity_group.developers](https://registry.terraform.io/providers/hashicorp/vault/latest/docs/resources/identity_group) | resource |
+| [vault_identity_oidc_key.key](https://registry.terraform.io/providers/hashicorp/vault/latest/docs/resources/identity_oidc_key) | resource |
+| [vault_identity_oidc_provider.cgdevx](https://registry.terraform.io/providers/hashicorp/vault/latest/docs/resources/identity_oidc_provider) | resource |
+| [vault_identity_oidc_scope.email_scope](https://registry.terraform.io/providers/hashicorp/vault/latest/docs/resources/identity_oidc_scope) | resource |
+| [vault_identity_oidc_scope.group_scope](https://registry.terraform.io/providers/hashicorp/vault/latest/docs/resources/identity_oidc_scope) | resource |
+| [vault_identity_oidc_scope.profile_scope](https://registry.terraform.io/providers/hashicorp/vault/latest/docs/resources/identity_oidc_scope) | resource |
+| [vault_identity_oidc_scope.user_scope](https://registry.terraform.io/providers/hashicorp/vault/latest/docs/resources/identity_oidc_scope) | resource |
+| [vault_kubernetes_auth_backend_config.k8s](https://registry.terraform.io/providers/hashicorp/vault/latest/docs/resources/kubernetes_auth_backend_config) | resource |
+| [vault_kubernetes_auth_backend_role.k8s_atlantis](https://registry.terraform.io/providers/hashicorp/vault/latest/docs/resources/kubernetes_auth_backend_role) | resource |
+| [vault_kubernetes_auth_backend_role.k8s_external_secrets](https://registry.terraform.io/providers/hashicorp/vault/latest/docs/resources/kubernetes_auth_backend_role) | resource |
+| [vault_mount.secret](https://registry.terraform.io/providers/hashicorp/vault/latest/docs/resources/mount) | resource |
+| [vault_mount.users](https://registry.terraform.io/providers/hashicorp/vault/latest/docs/resources/mount) | resource |
+| [vault_mount.workloads](https://registry.terraform.io/providers/hashicorp/vault/latest/docs/resources/mount) | resource |
+| [vault_policy.admin](https://registry.terraform.io/providers/hashicorp/vault/latest/docs/resources/policy) | resource |
+| [vault_policy.developer](https://registry.terraform.io/providers/hashicorp/vault/latest/docs/resources/policy) | resource |
 
 ## Inputs
 
-| Name                                                                                                                         | Description                    | Type                                                                                          | Default | Required |
-|------------------------------------------------------------------------------------------------------------------------------|--------------------------------|-----------------------------------------------------------------------------------------------|---------|:--------:|
-| <a name="input_atlantis_repo_webhook_secret"></a> [atlantis\_repo\_webhook\_secret](#input\_atlantis\_repo\_webhook\_secret) | atlantis webhook secret        | `string`                                                                                      | `""`    |    no    |
-| <a name="input_atlantis_repo_webhook_url"></a> [atlantis\_repo\_webhook\_url](#input\_atlantis\_repo\_webhook\_url)          | atlantis webhook url           | `string`                                                                                      | `""`    |    no    |
-| <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name)                                                     | primary cluster name           | `string`                                                                                      | `""`    |    no    |
-| <a name="input_vault_token"></a> [vault\_token](#input\_vault\_token)                                                        | vault token                    | `string`                                                                                      | `""`    |    no    |
-| <a name="input_vcs_bot_ssh_private_key"></a> [vcs\_bot\_ssh\_private\_key](#input\_vcs\_bot\_ssh\_private\_key)              | private key for git operations | `string`                                                                                      | `""`    |    no    |
-| <a name="input_vcs_bot_ssh_public_key"></a> [vcs\_bot\_ssh\_public\_key](#input\_vcs\_bot\_ssh\_public\_key)                 | public key for git operations  | `string`                                                                                      | `""`    |    no    |
-| <a name="input_vcs_token"></a> [vcs\_token](#input\_vcs\_token)                                                              | token for git operations       | `string`                                                                                      | `""`    |    no    |
-| <a name="input_workloads"></a> [workloads](#input\_workloads)                                                                | workloads vault configuration  | <pre>map(object({<br>    description                  = optional(string, "")<br>    }))</pre> | `{}`    |    no    |
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_argocd_webhook_secret"></a> [argocd\_webhook\_secret](#input\_argocd\_webhook\_secret) | argocd webhook secret | `string` | `""` | no |
+| <a name="input_atlantis_repo_webhook_secret"></a> [atlantis\_repo\_webhook\_secret](#input\_atlantis\_repo\_webhook\_secret) | atlantis webhook secret | `string` | `""` | no |
+| <a name="input_atlantis_repo_webhook_url"></a> [atlantis\_repo\_webhook\_url](#input\_atlantis\_repo\_webhook\_url) | atlantis webhook url | `string` | `""` | no |
+| <a name="input_cluster_endpoint"></a> [cluster\_endpoint](#input\_cluster\_endpoint) | (Required) K8s cluster endpoint | `string` | n/a | yes |
+| <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | primary cluster name | `string` | `""` | no |
+| <a name="input_cluster_ssh_public_key"></a> [cluster\_ssh\_public\_key](#input\_cluster\_ssh\_public\_key) | Specifies the SSH public key for K8s worker nodes. Only applicable to AKS. | `string` | `null` | no |
+| <a name="input_tf_backend_storage_access_key"></a> [tf\_backend\_storage\_access\_key](#input\_tf\_backend\_storage\_access\_key) | Specifies the access key for tf backend storage. Only applicable to AKS. | `string` | `""` | no |
+| <a name="input_vault_token"></a> [vault\_token](#input\_vault\_token) | vault token | `string` | `""` | no |
+| <a name="input_vcs_bot_ssh_private_key"></a> [vcs\_bot\_ssh\_private\_key](#input\_vcs\_bot\_ssh\_private\_key) | private key for git operations | `string` | `""` | no |
+| <a name="input_vcs_bot_ssh_public_key"></a> [vcs\_bot\_ssh\_public\_key](#input\_vcs\_bot\_ssh\_public\_key) | public key for git operations | `string` | `""` | no |
+| <a name="input_vcs_token"></a> [vcs\_token](#input\_vcs\_token) | token for git operations | `string` | `""` | no |
+| <a name="input_workloads"></a> [workloads](#input\_workloads) | workloads vault configuration | <pre>map(object({<br>    description = optional(string, "")<br>  }))</pre> | `{}` | no |
 
 ## Outputs
 
-No outputs.
+| Name | Description |
+|------|-------------|
+| <a name="output_code_quality_admin_password"></a> [code\_quality\_admin\_password](#output\_code\_quality\_admin\_password) | code quality password |
+| <a name="output_code_quality_oidc_client_id"></a> [code\_quality\_oidc\_client\_id](#output\_code\_quality\_oidc\_client\_id) | code quality OIDC client ID |
+| <a name="output_code_quality_oidc_client_secret"></a> [code\_quality\_oidc\_client\_secret](#output\_code\_quality\_oidc\_client\_secret) | code quality OIDC client secret |
+| <a name="output_registry_admin_password"></a> [registry\_admin\_password](#output\_registry\_admin\_password) | admin password |
+| <a name="output_registry_main_robot_password"></a> [registry\_main\_robot\_password](#output\_registry\_main\_robot\_password) | main-robot password |
+| <a name="output_registry_oidc_client_id"></a> [registry\_oidc\_client\_id](#output\_registry\_oidc\_client\_id) | Registry OIDC client ID |
+| <a name="output_registry_oidc_client_secret"></a> [registry\_oidc\_client\_secret](#output\_registry\_oidc\_client\_secret) | Registry OIDC client secret |
 <!-- END_TF_DOCS -->

--- a/platform/terraform/modules/secrets_vault/TERRAFORM-README.md
+++ b/platform/terraform/modules/secrets_vault/TERRAFORM-README.md
@@ -65,7 +65,7 @@ No requirements.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_argocd_webhook_secret"></a> [argocd\_webhook\_secret](#input\_argocd\_webhook\_secret) | argocd webhook secret | `string` | `""` | no |
+| <a name="input_cd_webhook_secret"></a> [cd\_webhook\_secret](#input\_cd\_webhook\_secret) | cd webhook secret | `string` | `""` | no |
 | <a name="input_atlantis_repo_webhook_secret"></a> [atlantis\_repo\_webhook\_secret](#input\_atlantis\_repo\_webhook\_secret) | atlantis webhook secret | `string` | `""` | no |
 | <a name="input_atlantis_repo_webhook_url"></a> [atlantis\_repo\_webhook\_url](#input\_atlantis\_repo\_webhook\_url) | atlantis webhook url | `string` | `""` | no |
 | <a name="input_cluster_endpoint"></a> [cluster\_endpoint](#input\_cluster\_endpoint) | (Required) K8s cluster endpoint | `string` | n/a | yes |

--- a/platform/terraform/modules/secrets_vault/secrets.tf
+++ b/platform/terraform/modules/secrets_vault/secrets.tf
@@ -43,6 +43,15 @@ resource "vault_generic_secret" "ci_secrets" {
   depends_on = [vault_mount.secret]
 }
 
+resource "vault_generic_secret" "argocd_secrets" {
+  path = "secret/argocd-secrets"
+
+  data_json = jsonencode(
+    {
+      argocd_webhook_secret         = var.argocd_webhook_secret,
+    }
+  )
+
 resource "vault_generic_secret" "atlantis_secrets" {
   path = "secret/atlantis/envs-secrets"
 
@@ -60,6 +69,7 @@ resource "vault_generic_secret" "atlantis_secrets" {
       GITHUB_OWNER                         = "<GIT_ORGANIZATION_NAME>",
       GITHUB_TOKEN                         = var.vcs_token,
       # ----
+      TF_VAR_argocd_webhook_secret         = var.argocd_webhook_secret,
       TF_VAR_atlantis_repo_webhook_secret  = var.atlantis_repo_webhook_secret,
       TF_VAR_atlantis_repo_webhook_url     = var.atlantis_repo_webhook_url,
       TF_VAR_vcs_token                     = var.vcs_token,

--- a/platform/terraform/modules/secrets_vault/secrets.tf
+++ b/platform/terraform/modules/secrets_vault/secrets.tf
@@ -43,12 +43,12 @@ resource "vault_generic_secret" "ci_secrets" {
   depends_on = [vault_mount.secret]
 }
 
-resource "vault_generic_secret" "argocd_secrets" {
-  path = "secret/argocd-secrets"
+resource "vault_generic_secret" "cd_secrets" {
+  path = "secret/cd-secrets"
 
   data_json = jsonencode(
     {
-      argocd_webhook_secret         = var.argocd_webhook_secret,
+      cd_webhook_secret         = var.cd_webhook_secret,
     }
   )
 
@@ -72,7 +72,7 @@ resource "vault_generic_secret" "atlantis_secrets" {
       GITHUB_OWNER                         = "<GIT_ORGANIZATION_NAME>",
       GITHUB_TOKEN                         = var.vcs_token,
       # ----
-      TF_VAR_argocd_webhook_secret         = var.argocd_webhook_secret,
+      TF_VAR_cd_webhook_secret             = var.cd_webhook_secret,
       TF_VAR_atlantis_repo_webhook_secret  = var.atlantis_repo_webhook_secret,
       TF_VAR_atlantis_repo_webhook_url     = var.atlantis_repo_webhook_url,
       TF_VAR_vcs_token                     = var.vcs_token,

--- a/platform/terraform/modules/secrets_vault/secrets.tf
+++ b/platform/terraform/modules/secrets_vault/secrets.tf
@@ -52,6 +52,9 @@ resource "vault_generic_secret" "argocd_secrets" {
     }
   )
 
+  depends_on = [vault_mount.secret]
+}
+
 resource "vault_generic_secret" "atlantis_secrets" {
   path = "secret/atlantis/envs-secrets"
 

--- a/platform/terraform/modules/secrets_vault/variables.tf
+++ b/platform/terraform/modules/secrets_vault/variables.tf
@@ -38,6 +38,13 @@ variable "atlantis_repo_webhook_url" {
   type        = string
 }
 
+variable "argocd_webhook_secret" {
+  description = "argocd webhook secret"
+  default     = ""
+  type        = string
+  sensitive   = true
+}
+
 variable "vault_token" {
   description = "vault token"
   default     = ""

--- a/platform/terraform/modules/secrets_vault/variables.tf
+++ b/platform/terraform/modules/secrets_vault/variables.tf
@@ -38,8 +38,8 @@ variable "atlantis_repo_webhook_url" {
   type        = string
 }
 
-variable "argocd_webhook_secret" {
-  description = "argocd webhook secret"
+variable "cd_webhook_secret" {
+  description = "cd webhook secret"
   default     = ""
   type        = string
   sensitive   = true

--- a/platform/terraform/modules/vcs_github/TERRAFORM-README.md
+++ b/platform/terraform/modules/vcs_github/TERRAFORM-README.md
@@ -1,0 +1,50 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_github"></a> [github](#requirement\_github) | ~> <GITHUB_PROVIDER_VERSION> |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_github"></a> [github](#provider\_github) | ~> <GITHUB_PROVIDER_VERSION> |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_gitops-repo"></a> [gitops-repo](#module\_gitops-repo) | ./repository | n/a |
+| <a name="module_workload_repos"></a> [workload\_repos](#module\_workload\_repos) | ./repository | n/a |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [github_actions_runner_group.this](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/actions_runner_group) | resource |
+| [github_user_ssh_key.vcs-bot](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/user_ssh_key) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_argocd_webhook_secret"></a> [argocd\_webhook\_secret](#input\_argocd\_webhook\_secret) | n/a | `string` | `""` | no |
+| <a name="input_argocd_webhook_url"></a> [argocd\_webhook\_url](#input\_argocd\_webhook\_url) | n/a | `string` | `""` | no |
+| <a name="input_atlantis_repo_webhook_secret"></a> [atlantis\_repo\_webhook\_secret](#input\_atlantis\_repo\_webhook\_secret) | n/a | `string` | `""` | no |
+| <a name="input_atlantis_url"></a> [atlantis\_url](#input\_atlantis\_url) | n/a | `string` | `""` | no |
+| <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | n/a | `string` | `""` | no |
+| <a name="input_gitops_repo_name"></a> [gitops\_repo\_name](#input\_gitops\_repo\_name) | n/a | `string` | `"gitops"` | no |
+| <a name="input_vcs_bot_ssh_public_key"></a> [vcs\_bot\_ssh\_public\_key](#input\_vcs\_bot\_ssh\_public\_key) | n/a | `string` | `""` | no |
+| <a name="input_vcs_owner"></a> [vcs\_owner](#input\_vcs\_owner) | n/a | `string` | `""` | no |
+| <a name="input_vcs_subscription_plan"></a> [vcs\_subscription\_plan](#input\_vcs\_subscription\_plan) | True for advanced github/gitlab plan. False for free tier | `bool` | `false` | no |
+| <a name="input_workloads"></a> [workloads](#input\_workloads) | workloads configuration | <pre>map(object({<br>    description = optional(string, "")<br>    repos       = map(object({<br>      description            = optional(string, "")<br>      visibility             = optional(string, "private")<br>      auto_init              = optional(bool, false)<br>      archive_on_destroy     = optional(bool, false)<br>      has_issues             = optional(bool, false)<br>      default_branch_name    = optional(string, "main")<br>      delete_branch_on_merge = optional(bool, true)<br>      branch_protection      = optional(bool, true)<br>      atlantis_enabled       = optional(bool, false)<br>    }))<br>  }))</pre> | `{}` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_gitops_repo_git_clone_url"></a> [gitops\_repo\_git\_clone\_url](#output\_gitops\_repo\_git\_clone\_url) | n/a |
+| <a name="output_gitops_repo_html_url"></a> [gitops\_repo\_html\_url](#output\_gitops\_repo\_html\_url) | n/a |
+| <a name="output_gitops_repo_ssh_clone_url"></a> [gitops\_repo\_ssh\_clone\_url](#output\_gitops\_repo\_ssh\_clone\_url) | n/a |
+<!-- END_TF_DOCS -->

--- a/platform/terraform/modules/vcs_github/TERRAFORM-README.md
+++ b/platform/terraform/modules/vcs_github/TERRAFORM-README.md
@@ -29,8 +29,8 @@
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_argocd_webhook_secret"></a> [argocd\_webhook\_secret](#input\_argocd\_webhook\_secret) | n/a | `string` | `""` | no |
-| <a name="input_argocd_webhook_url"></a> [argocd\_webhook\_url](#input\_argocd\_webhook\_url) | n/a | `string` | `""` | no |
+| <a name="input_cd_webhook_secret"></a> [cd\_webhook\_secret](#input\_cd\_webhook\_secret) | n/a | `string` | `""` | no |
+| <a name="input_cd_webhook_url"></a> [cd\_webhook\_url](#input\_cd\_webhook\_url) | n/a | `string` | `""` | no |
 | <a name="input_atlantis_repo_webhook_secret"></a> [atlantis\_repo\_webhook\_secret](#input\_atlantis\_repo\_webhook\_secret) | n/a | `string` | `""` | no |
 | <a name="input_atlantis_url"></a> [atlantis\_url](#input\_atlantis\_url) | n/a | `string` | `""` | no |
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | n/a | `string` | `""` | no |

--- a/platform/terraform/modules/vcs_github/gitops_repo.tf
+++ b/platform/terraform/modules/vcs_github/gitops_repo.tf
@@ -6,8 +6,8 @@ module "gitops-repo" {
   atlantis_enabled             = true
   atlantis_url                 = var.atlantis_url
   atlantis_repo_webhook_secret = var.atlantis_repo_webhook_secret
-  argocd_webhook_url           = var.argocd_webhook_url
-  argocd_webhook_secret        = var.argocd_webhook_secret
+  cd_webhook_url               = var.cd_webhook_url
+  cd_webhook_secret            = var.cd_webhook_secret
   vcs_subscription_plan        = var.vcs_subscription_plan
 }
 

--- a/platform/terraform/modules/vcs_github/gitops_repo.tf
+++ b/platform/terraform/modules/vcs_github/gitops_repo.tf
@@ -6,6 +6,8 @@ module "gitops-repo" {
   atlantis_enabled             = true
   atlantis_url                 = var.atlantis_url
   atlantis_repo_webhook_secret = var.atlantis_repo_webhook_secret
+  argocd_webhook_url           = var.argocd_webhook_url
+  argocd_webhook_secret        = var.argocd_webhook_secret
   vcs_subscription_plan        = var.vcs_subscription_plan
 }
 

--- a/platform/terraform/modules/vcs_github/repository/variable.tf
+++ b/platform/terraform/modules/vcs_github/repository/variable.tf
@@ -69,6 +69,17 @@ variable "atlantis_repo_webhook_secret" {
   sensitive = true
 }
 
+variable "argocd_webhook_secret" {
+  type      = string
+  default   = ""
+  sensitive = true
+}
+
+variable "argocd_webhook_url" {
+  type    = string
+  default = ""
+}
+
 variable "vcs_subscription_plan" {
   description = "True for advanced github/gitlab plan. False for free tier"
   type    = bool

--- a/platform/terraform/modules/vcs_github/repository/variable.tf
+++ b/platform/terraform/modules/vcs_github/repository/variable.tf
@@ -69,13 +69,13 @@ variable "atlantis_repo_webhook_secret" {
   sensitive = true
 }
 
-variable "argocd_webhook_secret" {
+variable "cd_webhook_secret" {
   type      = string
   default   = ""
   sensitive = true
 }
 
-variable "argocd_webhook_url" {
+variable "cd_webhook_url" {
   type    = string
   default = ""
 }

--- a/platform/terraform/modules/vcs_github/repository/webhook.tf
+++ b/platform/terraform/modules/vcs_github/repository/webhook.tf
@@ -13,3 +13,19 @@ resource "github_repository_webhook" "gitops_atlantis_webhook" {
 
   events = ["pull_request_review", "push", "issue_comment", "pull_request"]
 }
+
+resource "github_repository_webhook" "gitops_argocd_webhook" {
+  count      = var.atlantis_enabled ? 1 : 0
+  repository = github_repository.repo.name
+
+  configuration {
+    content_type = "json"
+    insecure_ssl = false
+    url          = var.argocd_webhook_url
+    secret       = var.argocd_webhook_secret
+  }
+
+  active = true
+
+  events = ["push"]
+}

--- a/platform/terraform/modules/vcs_github/repository/webhook.tf
+++ b/platform/terraform/modules/vcs_github/repository/webhook.tf
@@ -14,15 +14,15 @@ resource "github_repository_webhook" "gitops_atlantis_webhook" {
   events = ["pull_request_review", "push", "issue_comment", "pull_request"]
 }
 
-resource "github_repository_webhook" "gitops_argocd_webhook" {
+resource "github_repository_webhook" "gitops_cd_webhook" {
   count      = var.atlantis_enabled ? 1 : 0
   repository = github_repository.repo.name
 
   configuration {
     content_type = "json"
     insecure_ssl = false
-    url          = var.argocd_webhook_url
-    secret       = var.argocd_webhook_secret
+    url          = var.cd_webhook_url
+    secret       = var.cd_webhook_secret
   }
 
   active = true

--- a/platform/terraform/modules/vcs_github/variable.tf
+++ b/platform/terraform/modules/vcs_github/variable.tf
@@ -9,6 +9,17 @@ variable "atlantis_url" {
   default = ""
 }
 
+variable "argocd_webhook_secret" {
+  type      = string
+  default   = ""
+  sensitive = true
+}
+
+variable "argocd_webhook_url" {
+  type    = string
+  default = ""
+}
+
 variable "gitops_repo_name" {
   type    = string
   default = "gitops"

--- a/platform/terraform/modules/vcs_github/variable.tf
+++ b/platform/terraform/modules/vcs_github/variable.tf
@@ -9,13 +9,13 @@ variable "atlantis_url" {
   default = ""
 }
 
-variable "argocd_webhook_secret" {
+variable "cd_webhook_secret" {
   type      = string
   default   = ""
   sensitive = true
 }
 
-variable "argocd_webhook_url" {
+variable "cd_webhook_url" {
   type    = string
   default = ""
 }

--- a/platform/terraform/modules/vcs_github/workload_repos.tf
+++ b/platform/terraform/modules/vcs_github/workload_repos.tf
@@ -19,4 +19,6 @@ module "workload_repos" {
   atlantis_enabled             = each.value.atlantis_enabled
   atlantis_url                 = var.atlantis_url
   atlantis_repo_webhook_secret = var.atlantis_repo_webhook_secret
+  argocd_webhook_url           = var.argocd_webhook_url
+  argocd_webhook_secret        = var.argocd_webhook_secret
 }

--- a/platform/terraform/modules/vcs_github/workload_repos.tf
+++ b/platform/terraform/modules/vcs_github/workload_repos.tf
@@ -19,6 +19,6 @@ module "workload_repos" {
   atlantis_enabled             = each.value.atlantis_enabled
   atlantis_url                 = var.atlantis_url
   atlantis_repo_webhook_secret = var.atlantis_repo_webhook_secret
-  argocd_webhook_url           = var.argocd_webhook_url
-  argocd_webhook_secret        = var.argocd_webhook_secret
+  cd_webhook_url               = var.cd_webhook_url
+  cd_webhook_secret            = var.cd_webhook_secret
 }

--- a/platform/terraform/modules/vcs_gitlab/TERRAFORM-README.md
+++ b/platform/terraform/modules/vcs_gitlab/TERRAFORM-README.md
@@ -1,0 +1,50 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_gitlab"></a> [gitlab](#requirement\_gitlab) | <GITLAB_PROVIDER_VERSION> |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_gitlab"></a> [gitlab](#provider\_gitlab) | <GITLAB_PROVIDER_VERSION> |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_gitops-repo"></a> [gitops-repo](#module\_gitops-repo) | ./repository | n/a |
+| <a name="module_workload_repos"></a> [workload\_repos](#module\_workload\_repos) | ./repository | n/a |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [gitlab_user_sshkey.vcs-bot](https://registry.terraform.io/providers/gitlabhq/gitlab/latest/docs/resources/user_sshkey) | resource |
+| [gitlab_group.owner](https://registry.terraform.io/providers/gitlabhq/gitlab/latest/docs/data-sources/group) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_argocd_webhook_secret"></a> [argocd\_webhook\_secret](#input\_argocd\_webhook\_secret) | n/a | `string` | `""` | no |
+| <a name="input_argocd_webhook_url"></a> [argocd\_webhook\_url](#input\_argocd\_webhook\_url) | n/a | `string` | `""` | no |
+| <a name="input_atlantis_repo_webhook_secret"></a> [atlantis\_repo\_webhook\_secret](#input\_atlantis\_repo\_webhook\_secret) | n/a | `string` | `""` | no |
+| <a name="input_atlantis_url"></a> [atlantis\_url](#input\_atlantis\_url) | n/a | `string` | `""` | no |
+| <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | n/a | `string` | `""` | no |
+| <a name="input_gitops_repo_name"></a> [gitops\_repo\_name](#input\_gitops\_repo\_name) | n/a | `string` | `"gitops"` | no |
+| <a name="input_vcs_bot_ssh_public_key"></a> [vcs\_bot\_ssh\_public\_key](#input\_vcs\_bot\_ssh\_public\_key) | n/a | `string` | `""` | no |
+| <a name="input_vcs_owner"></a> [vcs\_owner](#input\_vcs\_owner) | n/a | `string` | `""` | no |
+| <a name="input_vcs_subscription_plan"></a> [vcs\_subscription\_plan](#input\_vcs\_subscription\_plan) | True for advanced github/gitlab plan. False for free tier | `bool` | `false` | no |
+| <a name="input_workloads"></a> [workloads](#input\_workloads) | workloads configuration | <pre>map(object({<br>    description = optional(string, "")<br>    repos = map(object({<br>      description            = optional(string, "")<br>      visibility             = optional(string, "private")<br>      auto_init              = optional(bool, false)<br>      archive_on_destroy     = optional(bool, false)<br>      has_issues             = optional(bool, false)<br>      default_branch_name    = optional(string, "main")<br>      delete_branch_on_merge = optional(bool, true)<br>      branch_protection      = optional(bool, true)<br>      atlantis_enabled       = optional(bool, false)<br>    }))<br>  }))</pre> | `{}` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_gitops_repo_git_clone_url"></a> [gitops\_repo\_git\_clone\_url](#output\_gitops\_repo\_git\_clone\_url) | n/a |
+| <a name="output_gitops_repo_html_url"></a> [gitops\_repo\_html\_url](#output\_gitops\_repo\_html\_url) | n/a |
+| <a name="output_gitops_repo_ssh_clone_url"></a> [gitops\_repo\_ssh\_clone\_url](#output\_gitops\_repo\_ssh\_clone\_url) | n/a |
+<!-- END_TF_DOCS -->

--- a/platform/terraform/modules/vcs_gitlab/TERRAFORM-README.md
+++ b/platform/terraform/modules/vcs_gitlab/TERRAFORM-README.md
@@ -29,8 +29,8 @@
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_argocd_webhook_secret"></a> [argocd\_webhook\_secret](#input\_argocd\_webhook\_secret) | n/a | `string` | `""` | no |
-| <a name="input_argocd_webhook_url"></a> [argocd\_webhook\_url](#input\_argocd\_webhook\_url) | n/a | `string` | `""` | no |
+| <a name="input_cd_webhook_secret"></a> [cd\_webhook\_secret](#input\_cd\_webhook\_secret) | n/a | `string` | `""` | no |
+| <a name="input_cd_webhook_url"></a> [cd\_webhook\_url](#input\_cd\_webhook\_url) | n/a | `string` | `""` | no |
 | <a name="input_atlantis_repo_webhook_secret"></a> [atlantis\_repo\_webhook\_secret](#input\_atlantis\_repo\_webhook\_secret) | n/a | `string` | `""` | no |
 | <a name="input_atlantis_url"></a> [atlantis\_url](#input\_atlantis\_url) | n/a | `string` | `""` | no |
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | n/a | `string` | `""` | no |

--- a/platform/terraform/modules/vcs_gitlab/gitops_repo.tf
+++ b/platform/terraform/modules/vcs_gitlab/gitops_repo.tf
@@ -6,6 +6,8 @@ module "gitops-repo" {
   atlantis_enabled             = true
   atlantis_url                 = var.atlantis_url
   atlantis_repo_webhook_secret = var.atlantis_repo_webhook_secret
+  argocd_webhook_url           = var.argocd_webhook_url
+  argocd_webhook_secret        = var.argocd_webhook_secret
   vcs_subscription_plan        = var.vcs_subscription_plan
   vcs_owner                    = data.gitlab_group.owner.group_id
   branch_protection            = true

--- a/platform/terraform/modules/vcs_gitlab/gitops_repo.tf
+++ b/platform/terraform/modules/vcs_gitlab/gitops_repo.tf
@@ -6,8 +6,8 @@ module "gitops-repo" {
   atlantis_enabled             = true
   atlantis_url                 = var.atlantis_url
   atlantis_repo_webhook_secret = var.atlantis_repo_webhook_secret
-  argocd_webhook_url           = var.argocd_webhook_url
-  argocd_webhook_secret        = var.argocd_webhook_secret
+  cd_webhook_url               = var.cd_webhook_url
+  cd_webhook_secret            = var.cd_webhook_secret
   vcs_subscription_plan        = var.vcs_subscription_plan
   vcs_owner                    = data.gitlab_group.owner.group_id
   branch_protection            = true

--- a/platform/terraform/modules/vcs_gitlab/repository/variable.tf
+++ b/platform/terraform/modules/vcs_gitlab/repository/variable.tf
@@ -69,6 +69,17 @@ variable "atlantis_repo_webhook_secret" {
   sensitive = true
 }
 
+variable "argocd_webhook_secret" {
+  type      = string
+  default   = ""
+  sensitive = true
+}
+
+variable "argocd_webhook_url" {
+  type    = string
+  default = ""
+}
+
 variable "vcs_subscription_plan" {
   description = "True for advanced github/gitlab plan. False for free tier"
   type        = bool

--- a/platform/terraform/modules/vcs_gitlab/repository/variable.tf
+++ b/platform/terraform/modules/vcs_gitlab/repository/variable.tf
@@ -69,13 +69,13 @@ variable "atlantis_repo_webhook_secret" {
   sensitive = true
 }
 
-variable "argocd_webhook_secret" {
+variable "cd_webhook_secret" {
   type      = string
   default   = ""
   sensitive = true
 }
 
-variable "argocd_webhook_url" {
+variable "cd_webhook_url" {
   type    = string
   default = ""
 }

--- a/platform/terraform/modules/vcs_gitlab/repository/webhook.tf
+++ b/platform/terraform/modules/vcs_gitlab/repository/webhook.tf
@@ -12,3 +12,18 @@ resource "gitlab_project_hook" "gitops_atlantis_webhook" {
   note_events           = true
 
 }
+
+resource "gitlab_project_hook" "gitops_argocd_webhook" {
+  count   = var.atlantis_enabled ? 1 : 0
+  project = gitlab_project.repo.id
+
+
+  url                     = var.argocd_webhook_url
+  enable_ssl_verification = true
+  token                   = var.argocd_webhook_secret
+
+  merge_requests_events = false
+  push_events           = true
+  note_events           = false
+
+}

--- a/platform/terraform/modules/vcs_gitlab/repository/webhook.tf
+++ b/platform/terraform/modules/vcs_gitlab/repository/webhook.tf
@@ -13,14 +13,14 @@ resource "gitlab_project_hook" "gitops_atlantis_webhook" {
 
 }
 
-resource "gitlab_project_hook" "gitops_argocd_webhook" {
+resource "gitlab_project_hook" "gitops_cd_webhook" {
   count   = var.atlantis_enabled ? 1 : 0
   project = gitlab_project.repo.id
 
 
-  url                     = var.argocd_webhook_url
+  url                     = var.cd_webhook_url
   enable_ssl_verification = true
-  token                   = var.argocd_webhook_secret
+  token                   = var.cd_webhook_secret
 
   merge_requests_events = false
   push_events           = true

--- a/platform/terraform/modules/vcs_gitlab/variable.tf
+++ b/platform/terraform/modules/vcs_gitlab/variable.tf
@@ -9,6 +9,17 @@ variable "atlantis_url" {
   default = ""
 }
 
+variable "argocd_webhook_secret" {
+  type      = string
+  default   = ""
+  sensitive = true
+}
+
+variable "argocd_webhook_url" {
+  type    = string
+  default = ""
+}
+
 variable "gitops_repo_name" {
   type    = string
   default = "gitops"

--- a/platform/terraform/modules/vcs_gitlab/variable.tf
+++ b/platform/terraform/modules/vcs_gitlab/variable.tf
@@ -9,13 +9,13 @@ variable "atlantis_url" {
   default = ""
 }
 
-variable "argocd_webhook_secret" {
+variable "cd_webhook_secret" {
   type      = string
   default   = ""
   sensitive = true
 }
 
-variable "argocd_webhook_url" {
+variable "cd_webhook_url" {
   type    = string
   default = ""
 }

--- a/platform/terraform/modules/vcs_gitlab/workload_repos.tf
+++ b/platform/terraform/modules/vcs_gitlab/workload_repos.tf
@@ -19,5 +19,7 @@ module "workload_repos" {
   atlantis_enabled             = each.value.atlantis_enabled
   atlantis_url                 = var.atlantis_url
   atlantis_repo_webhook_secret = var.atlantis_repo_webhook_secret
+  argocd_webhook_url           = var.argocd_webhook_url
+  argocd_webhook_secret        = var.argocd_webhook_secret
   vcs_owner                    = data.gitlab_group.owner.group_id
 }

--- a/platform/terraform/modules/vcs_gitlab/workload_repos.tf
+++ b/platform/terraform/modules/vcs_gitlab/workload_repos.tf
@@ -19,7 +19,7 @@ module "workload_repos" {
   atlantis_enabled             = each.value.atlantis_enabled
   atlantis_url                 = var.atlantis_url
   atlantis_repo_webhook_secret = var.atlantis_repo_webhook_secret
-  argocd_webhook_url           = var.argocd_webhook_url
-  argocd_webhook_secret        = var.argocd_webhook_secret
+  cd_webhook_url               = var.cd_webhook_url
+  cd_webhook_secret            = var.cd_webhook_secret
   vcs_owner                    = data.gitlab_group.owner.group_id
 }

--- a/platform/terraform/secrets/README.md
+++ b/platform/terraform/secrets/README.md
@@ -23,14 +23,14 @@ atlantis_repo_webhook_secret = var.atlantis_repo_webhook_secret
 # IaC PR automation webhook URL
 atlantis_repo_webhook_url    = var.atlantis_repo_webhook_url
 # CD after push sync event webhook secret
-argocd_webhook_secret        = var.argocd_webhook_secret
+cd_webhook_secret            = var.cd_webhook_secret
 #Secrets Manager root access token
 vault_token                  = var.vault_token
 ```
 
 | Name                                                                                                                         | Description                    | Type     | Default | Required |
 |------------------------------------------------------------------------------------------------------------------------------|--------------------------------|----------|---------|:--------:|
-| <a name="input_argocd_webhook_secret"></a> [argocd\_webhook\_secret](#input\_argocd\_webhook\_secret) | argocd webhook secret        | `string` | `""`    |    no    |
+| <a name="input_cd_webhook_secret"></a> [cd\_webhook\_secret](#input\_cd\_webhook\_secret) | cd webhook secret        | `string` | `""`    |    no    |
 | <a name="input_atlantis_repo_webhook_secret"></a> [atlantis\_repo\_webhook\_secret](#input\_atlantis\_repo\_webhook\_secret) | atlantis webhook secret        | `string` | `""`    |    no    |
 | <a name="input_atlantis_repo_webhook_url"></a> [atlantis\_repo\_webhook\_url](#input\_atlantis\_repo\_webhook\_url)          | atlantis webhook url           | `string` | `""`    |    no    |
 | <a name="input_vault_token"></a> [vault\_token](#input\_vault\_token)                                                        | vault token                    | `string` | `""`    |    no    |

--- a/platform/terraform/secrets/README.md
+++ b/platform/terraform/secrets/README.md
@@ -22,12 +22,15 @@ vcs_token                    = var.vcs_token
 atlantis_repo_webhook_secret = var.atlantis_repo_webhook_secret
 # IaC PR automation webhook URL
 atlantis_repo_webhook_url    = var.atlantis_repo_webhook_url
+# CD after push sync event webhook secret
+argocd_webhook_secret        = var.argocd_webhook_secret
 #Secrets Manager root access token
 vault_token                  = var.vault_token
 ```
 
 | Name                                                                                                                         | Description                    | Type     | Default | Required |
 |------------------------------------------------------------------------------------------------------------------------------|--------------------------------|----------|---------|:--------:|
+| <a name="input_argocd_webhook_secret"></a> [argocd\_webhook\_secret](#input\_argocd\_webhook\_secret) | argocd webhook secret        | `string` | `""`    |    no    |
 | <a name="input_atlantis_repo_webhook_secret"></a> [atlantis\_repo\_webhook\_secret](#input\_atlantis\_repo\_webhook\_secret) | atlantis webhook secret        | `string` | `""`    |    no    |
 | <a name="input_atlantis_repo_webhook_url"></a> [atlantis\_repo\_webhook\_url](#input\_atlantis\_repo\_webhook\_url)          | atlantis webhook url           | `string` | `""`    |    no    |
 | <a name="input_vault_token"></a> [vault\_token](#input\_vault\_token)                                                        | vault token                    | `string` | `""`    |    no    |

--- a/platform/terraform/secrets/main.tf
+++ b/platform/terraform/secrets/main.tf
@@ -29,7 +29,7 @@ module "secrets" {
   vcs_token                    = var.vcs_token
   atlantis_repo_webhook_secret = var.atlantis_repo_webhook_secret
   atlantis_repo_webhook_url    = var.atlantis_repo_webhook_url
-  argocd_webhook_secret        = var.argocd_webhook_secret
+  cd_webhook_secret            = var.cd_webhook_secret
   vault_token                  = var.vault_token
   cluster_endpoint             = var.cluster_endpoint
   cluster_ssh_public_key       = var.cluster_ssh_public_key

--- a/platform/terraform/secrets/main.tf
+++ b/platform/terraform/secrets/main.tf
@@ -29,6 +29,7 @@ module "secrets" {
   vcs_token                    = var.vcs_token
   atlantis_repo_webhook_secret = var.atlantis_repo_webhook_secret
   atlantis_repo_webhook_url    = var.atlantis_repo_webhook_url
+  argocd_webhook_secret        = var.argocd_webhook_secret
   vault_token                  = var.vault_token
   cluster_endpoint             = var.cluster_endpoint
   cluster_ssh_public_key       = var.cluster_ssh_public_key

--- a/platform/terraform/secrets/variable.tf
+++ b/platform/terraform/secrets/variable.tf
@@ -31,8 +31,8 @@ variable "atlantis_repo_webhook_url" {
   type        = string
 }
 
-variable "argocd_webhook_secret" {
-  description = "argocd webhook secret"
+variable "cd_webhook_secret" {
+  description = "cd webhook secret"
   default     = ""
   type        = string
   sensitive   = true

--- a/platform/terraform/secrets/variable.tf
+++ b/platform/terraform/secrets/variable.tf
@@ -31,6 +31,13 @@ variable "atlantis_repo_webhook_url" {
   type        = string
 }
 
+variable "argocd_webhook_secret" {
+  description = "argocd webhook secret"
+  default     = ""
+  type        = string
+  sensitive   = true
+}
+
 variable "vault_token" {
   description = "vault token"
   default     = ""

--- a/platform/terraform/vcs/README.md
+++ b/platform/terraform/vcs/README.md
@@ -14,12 +14,15 @@ gitops_repo_name             = local.gitops_repo_name
 atlantis_url                 = local.atlantis_url
 # IaC PR automation webhook secret
 atlantis_repo_webhook_secret = var.atlantis_repo_webhook_secret
+# CD after push sync event webhook secret
+argocd_webhook_secret = var.argocd_webhook_secret
 # Git machine user SSH public key
 vcs_bot_ssh_public_key       = var.vcs_bot_ssh_public_key
 ```
 
 | Name                                                                                                                         | Description | Type     | Default | Required |
 |------------------------------------------------------------------------------------------------------------------------------|-------------|----------|---------|:--------:|
+| <a name="input_argocd_webhook_secret"></a> [argocd\_webhook\_secret](#input\_argocd\_webhook\_secret) | n/a         | `string` | `""`    |    no    |
 | <a name="input_atlantis_repo_webhook_secret"></a> [atlantis\_repo\_webhook\_secret](#input\_atlantis\_repo\_webhook\_secret) | n/a         | `string` | `""`    |    no    |
 | <a name="input_vcs_bot_ssh_public_key"></a> [vcs\_bot\_ssh\_public\_key](#input\_vcs\_bot\_ssh\_public\_key)                 | n/a         | `string` | `""`    |    no    |
 

--- a/platform/terraform/vcs/README.md
+++ b/platform/terraform/vcs/README.md
@@ -15,14 +15,14 @@ atlantis_url                 = local.atlantis_url
 # IaC PR automation webhook secret
 atlantis_repo_webhook_secret = var.atlantis_repo_webhook_secret
 # CD after push sync event webhook secret
-argocd_webhook_secret = var.argocd_webhook_secret
+cd_webhook_secret            = var.cd_webhook_secret
 # Git machine user SSH public key
 vcs_bot_ssh_public_key       = var.vcs_bot_ssh_public_key
 ```
 
 | Name                                                                                                                         | Description | Type     | Default | Required |
 |------------------------------------------------------------------------------------------------------------------------------|-------------|----------|---------|:--------:|
-| <a name="input_argocd_webhook_secret"></a> [argocd\_webhook\_secret](#input\_argocd\_webhook\_secret) | n/a         | `string` | `""`    |    no    |
+| <a name="input_cd_webhook_secret"></a> [cd\_webhook\_secret](#input\_cd\_webhook\_secret) | n/a         | `string` | `""`    |    no    |
 | <a name="input_atlantis_repo_webhook_secret"></a> [atlantis\_repo\_webhook\_secret](#input\_atlantis\_repo\_webhook\_secret) | n/a         | `string` | `""`    |    no    |
 | <a name="input_vcs_bot_ssh_public_key"></a> [vcs\_bot\_ssh\_public\_key](#input\_vcs\_bot\_ssh\_public\_key)                 | n/a         | `string` | `""`    |    no    |
 

--- a/platform/terraform/vcs/main.tf
+++ b/platform/terraform/vcs/main.tf
@@ -13,6 +13,7 @@ terraform {
 locals {
   gitops_repo_name      = "<GITOPS_REPOSITORY_NAME>"
   atlantis_url          = "https://<IAC_PR_AUTOMATION_INGRESS_URL>/events"
+  argocd_webhook_url    = "https://<CD_INGRESS_URL>/api/webhook"
   cluster_name          = "<PRIMARY_CLUSTER_NAME>"
   vcs_owner             = "<GIT_ORGANIZATION_NAME>"
   vcs_subscription_plan = <GIT_SUBSCRIPTION_PLAN> # bool true(paid plans) / false (free tier)
@@ -25,6 +26,8 @@ module "vcs" {
   gitops_repo_name             = local.gitops_repo_name
   atlantis_url                 = local.atlantis_url
   atlantis_repo_webhook_secret = var.atlantis_repo_webhook_secret
+  argocd_webhook_url           = local.argocd_webhook_url
+  argocd_webhook_secret        = var.argocd_webhook_secret
   vcs_bot_ssh_public_key       = var.vcs_bot_ssh_public_key
   workloads                    = var.workloads
   cluster_name                 = local.cluster_name

--- a/platform/terraform/vcs/variable.tf
+++ b/platform/terraform/vcs/variable.tf
@@ -3,6 +3,11 @@ variable "atlantis_repo_webhook_secret" {
   default = ""
 }
 
+variable "argocd_webhook_secret" {
+  type    = string
+  default = ""
+}
+
 variable "vcs_bot_ssh_public_key" {
   type    = string
   default = ""

--- a/platform/terraform/vcs/variable.tf
+++ b/platform/terraform/vcs/variable.tf
@@ -3,7 +3,7 @@ variable "atlantis_repo_webhook_secret" {
   default = ""
 }
 
-variable "argocd_webhook_secret" {
+variable "cd_webhook_secret" {
   type    = string
   default = ""
 }

--- a/tools/cli/commands/setup.py
+++ b/tools/cli/commands/setup.py
@@ -319,6 +319,7 @@ def setup(
         tf_wrapper = TfWrapper(LOCAL_TF_FOLDER_VCS)
         tf_wrapper.init()
         tf_wrapper.apply({"atlantis_repo_webhook_secret": p.parameters["<IAC_PR_AUTOMATION_WEBHOOK_SECRET>"],
+                          "cd_webhook_secret": p.parameters["<CD_PUSH_EVENT_WEBHOOK_SECRET>"],
                           "vcs_bot_ssh_public_key": p.parameters["<VCS_BOT_SSH_PUBLIC_KEY>"]})
         vcs_out = tf_wrapper.output()
 
@@ -722,6 +723,7 @@ def setup(
             "vcs_bot_ssh_public_key": p.internals["DEFAULT_SSH_PUBLIC_KEY"],
             "vcs_bot_ssh_private_key": p.internals["DEFAULT_SSH_PRIVATE_KEY"],
             "vcs_token": p.internals["GIT_ACCESS_TOKEN"],
+            "cd_webhook_secret": p.parameters["<CD_PUSH_EVENT_WEBHOOK_SECRET>"],
             "atlantis_repo_webhook_secret": p.parameters["<IAC_PR_AUTOMATION_WEBHOOK_SECRET>"],
             "atlantis_repo_webhook_url": p.parameters["<IAC_PR_AUTOMATION_WEBHOOK_URL>"],
             "vault_token": p.internals["VAULT_ROOT_TOKEN"],
@@ -967,6 +969,10 @@ def prepare_parameters(p):
     # set IaC webhook secret
     if "<IAC_PR_AUTOMATION_WEBHOOK_SECRET>" not in p.parameters:
         p.parameters["<IAC_PR_AUTOMATION_WEBHOOK_SECRET>"] = random_string_generator(20)
+
+    # set CD webhook secret
+    if "<CD_PUSH_EVENT_WEBHOOK_SECRET>" not in p.parameters:
+        p.parameters["<CD_PUSH_EVENT_WEBHOOK_SECRET>"] = random_string_generator(20)
 
     # Ingress URLs for core components. Note!: URL does not contain protocol
     cluster_fqdn = f'{p.get_input_param(DOMAIN_NAME)}'


### PR DESCRIPTION
### Requirements

* Argo CD polls Git repositories every three minutes to detect changes to the manifests. To eliminate this delay from polling, the server can be configured to receive webhook events. Argo CD supports Git webhook notifications from GitHub, GitLab

### Description of the Change

Generate secret in the cli during cluster init, store this secret as parameter in the state, use this secret as env var in terraform vcs init process, save secret in the vault secrets(for Atlantis and for argocd usage), expose this secret through external secret, patch argocd-secret for using this secret. Make it available for both supported VCS(github&gitlab)

### Documentation
https://argo-cd.readthedocs.io/en/stable/operator-manual/webhook/



