### PR TITLE
deps(helm): upgrade ArgoCD & core-services chart versions

### DIFF
--- a/platform/gitops-pipelines/delivery/clusters/cc-cluster/core-services/components/argo-workflows/application.yaml
+++ b/platform/gitops-pipelines/delivery/clusters/cc-cluster/core-services/components/argo-workflows/application.yaml
@@ -10,15 +10,15 @@ spec:
   project: core
   source:
     repoURL: https://argoproj.github.io/argo-helm
-    targetRevision: 0.45.15
+    targetRevision: 1.0.17
     helm:
       valuesObject:
         commonLabels:
           cg-devx.cost-allocation.cost-center: platform
           cg-devx.metadata.owner: <GITOPS_REPOSITORY_NAME>-admin
           cg-devx.metadata.service: continuous-integration.argo-workflow
-          cg-devx.metadata.chart-version: 0.45.15
-          cg-devx.metadata.version: 3.6.7
+          cg-devx.metadata.chart-version: 1.0.17
+          cg-devx.metadata.version: v4.0.6
         singleNamespace: false
         nameOverride: argo
         controller:

--- a/platform/gitops-pipelines/delivery/clusters/cc-cluster/core-services/components/argocd/label-transformer.yaml
+++ b/platform/gitops-pipelines/delivery/clusters/cc-cluster/core-services/components/argocd/label-transformer.yaml
@@ -7,7 +7,7 @@ labels:
   cg-devx.cost-allocation.cost-center: "platform"
   cg-devx.metadata.owner: "<GITOPS_REPOSITORY_NAME>-admin"
   cg-devx.metadata.service: "continuous-delivery.argocd"
-  cg-devx.metadata.version: "2.14.12"
+  cg-devx.metadata.version: "3.4.4"
 fieldSpecs:
 - path: metadata/labels
   create: true

--- a/platform/gitops-pipelines/delivery/clusters/cc-cluster/core-services/components/atlantis/application.yaml
+++ b/platform/gitops-pipelines/delivery/clusters/cc-cluster/core-services/components/atlantis/application.yaml
@@ -10,15 +10,15 @@ spec:
   source:
     repoURL: https://runatlantis.github.io/helm-charts
     chart: atlantis
-    targetRevision: 5.17.2
+    targetRevision: 6.6.0
     helm:
       values: |-
         commonLabels:
           cg-devx.cost-allocation.cost-center: platform
           cg-devx.metadata.owner: <GITOPS_REPOSITORY_NAME>-admin
           cg-devx.metadata.service: atlantis
-          cg-devx.metadata.chart-version: 5.17.2
-          cg-devx.metadata.version: 0.34.0
+          cg-devx.metadata.chart-version: 6.6.0
+          cg-devx.metadata.version: v0.44.0
         statefulSet:
           annotations:
             secret.reloader.stakater.com/reload: "atlantis-envs-secrets"
@@ -36,7 +36,7 @@ spec:
             cg-devx.metadata.owner: <GITOPS_REPOSITORY_NAME>-admin
             cg-devx.metadata.service: atlantis
             cg-devx.metadata.chart-version: 5.4.2
-            cg-devx.metadata.version: 0.28.5
+            cg-devx.metadata.version: v0.44.0
             # <ADDITIONAL_LABELS>
         resources:
           limits:

--- a/platform/gitops-pipelines/delivery/clusters/cc-cluster/core-services/components/backstage/application.yaml
+++ b/platform/gitops-pipelines/delivery/clusters/cc-cluster/core-services/components/backstage/application.yaml
@@ -10,14 +10,14 @@ spec:
   source:
     repoURL: https://backstage.github.io/charts
     chart: backstage
-    targetRevision: 1.6.0
+    targetRevision: 2.8.2
     helm:
       values: |-
         commonLabels:
           cg-devx.cost-allocation.cost-center: platform
           cg-devx.metadata.owner: <GITOPS_REPOSITORY_NAME>-admin
           cg-devx.metadata.service: developer-portal.backstage
-          cg-devx.metadata.chart-version: 1.6.0
+          cg-devx.metadata.chart-version: 2.8.2
           cg-devx.metadata.version: 1.17.0-next.2
         global:
           imageRegistry: ""
@@ -57,7 +57,6 @@ spec:
             tag: 1.17.0-next.2
             pullPolicy: Always
             pullSecrets: []
-            debug: false
           containerPorts:
             backend: 7007
           command: ["node", "packages/backend"]

--- a/platform/gitops-pipelines/delivery/clusters/cc-cluster/core-services/components/devsecops/kyverno/kyverno-policies.yaml
+++ b/platform/gitops-pipelines/delivery/clusters/cc-cluster/core-services/components/devsecops/kyverno/kyverno-policies.yaml
@@ -13,7 +13,7 @@ spec:
   source:
     chart: kyverno-policies
     repoURL: https://kyverno.github.io/kyverno
-    targetRevision: v3.4.1
+    targetRevision: v3.8.0
     helm:
       releaseName: kyverno-policies
       values: |
@@ -21,8 +21,8 @@ spec:
           cg-devx.cost-allocation.cost-center: platform
           cg-devx.metadata.owner: <GITOPS_REPOSITORY_NAME>-admin
           cg-devx.metadata.service: policy-engine.kyverno-policies
-          cg-devx.metadata.chart-version: 3.4.1
-          cg-devx.metadata.version: 1.14.1
+          cg-devx.metadata.chart-version: 3.8.0
+          cg-devx.metadata.version: v1.18.0
   syncPolicy:
     automated:
       prune: true

--- a/platform/gitops-pipelines/delivery/clusters/cc-cluster/core-services/components/devsecops/kyverno/kyverno.yaml
+++ b/platform/gitops-pipelines/delivery/clusters/cc-cluster/core-services/components/devsecops/kyverno/kyverno.yaml
@@ -13,7 +13,7 @@ spec:
   source:
     chart: kyverno
     repoURL: https://kyverno.github.io/kyverno
-    targetRevision: v3.4.1
+    targetRevision: v3.8.1
     helm:
       releaseName: kyverno
       values: |
@@ -21,8 +21,8 @@ spec:
           cg-devx.cost-allocation.cost-center: platform
           cg-devx.metadata.owner: <GITOPS_REPOSITORY_NAME>-admin
           cg-devx.metadata.service: policy-engine.kyverno
-          cg-devx.metadata.chart-version: 3.4.1
-          cg-devx.metadata.version: 1.14.1
+          cg-devx.metadata.chart-version: 3.8.1
+          cg-devx.metadata.version: v1.18.1
         global:
           imagePullSecrets:
            - name: docker-config

--- a/platform/gitops-pipelines/delivery/clusters/cc-cluster/core-services/components/devsecops/kyverno/policy-reporter.yaml
+++ b/platform/gitops-pipelines/delivery/clusters/cc-cluster/core-services/components/devsecops/kyverno/policy-reporter.yaml
@@ -13,7 +13,7 @@ spec:
   source:
     chart: policy-reporter
     repoURL: https://kyverno.github.io/policy-reporter
-    targetRevision: v3.1.4
+    targetRevision: v3.7.4
     helm:
       releaseName: policy-reporter
       values: |
@@ -22,8 +22,8 @@ spec:
             cg-devx.cost-allocation.cost-center: platform
             cg-devx.metadata.owner: <GITOPS_REPOSITORY_NAME>-admin
             cg-devx.metadata.service: policy-engine.kyverno-policy-reporter
-            cg-devx.metadata.chart-version: 3.1.4
-            cg-devx.metadata.version: 3.1.1          
+            cg-devx.metadata.chart-version: 3.7.4
+            cg-devx.metadata.version: 3.7.4          
         ui:
           enabled: true
         kyvernoPlugin:

--- a/platform/gitops-pipelines/delivery/clusters/cc-cluster/core-services/components/devsecops/tracee/tracee.yaml
+++ b/platform/gitops-pipelines/delivery/clusters/cc-cluster/core-services/components/devsecops/tracee/tracee.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: tracee
     repoURL: https://aquasecurity.github.io/helm-charts/
-    targetRevision: 0.23.1
+    targetRevision: 0.24.1
     helm:
       releaseName: tracee
       values: |
@@ -25,8 +25,8 @@ spec:
           cg-devx.cost-allocation.cost-center: platform
           cg-devx.metadata.owner: <GITOPS_REPOSITORY_NAME>-admin
           cg-devx.metadata.service: runtime-security.tracee
-          cg-devx.metadata.chart-version: 0.23.1
-          cg-devx.metadata.version: 0.23.1
+          cg-devx.metadata.chart-version: 0.24.1
+          cg-devx.metadata.version: 0.24.1
   syncPolicy:
     automated:
       prune: true

--- a/platform/gitops-pipelines/delivery/clusters/cc-cluster/core-services/components/devsecops/trivy/trivy-operator.yaml
+++ b/platform/gitops-pipelines/delivery/clusters/cc-cluster/core-services/components/devsecops/trivy/trivy-operator.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: trivy-operator
     repoURL: https://aquasecurity.github.io/helm-charts/
-    targetRevision: 0.28.1
+    targetRevision: 0.33.2
     helm:
       releaseName: trivy-operator
       values: |
@@ -28,8 +28,8 @@ spec:
             cg-devx.cost-allocation.cost-center: platform
             cg-devx.metadata.owner: <GITOPS_REPOSITORY_NAME>-admin
             cg-devx.metadata.service: runtime-vulnerability-analysis
-            cg-devx.metadata.chart-version: 0.28.1
-            cg-devx.metadata.version: 0.28.1
+            cg-devx.metadata.chart-version: 0.33.2
+            cg-devx.metadata.version: 0.31.2
         serviceMonitor:
           # enabled determines whether a serviceMonitor should be deployed
           enabled: true
@@ -37,16 +37,16 @@ spec:
             cg-devx.cost-allocation.cost-center: platform
             cg-devx.metadata.owner: <GITOPS_REPOSITORY_NAME>-admin
             cg-devx.metadata.service: runtime-vulnerability-analysis
-            cg-devx.metadata.chart-version: 0.28.1
-            cg-devx.metadata.version: 0.28.1
+            cg-devx.metadata.chart-version: 0.33.2
+            cg-devx.metadata.version: 0.31.2
         operator:
           metricsVulnIdEnabled: true
           labels:
             cg-devx.cost-allocation.cost-center: platform
             cg-devx.metadata.owner: <GITOPS_REPOSITORY_NAME>-admin
             cg-devx.metadata.service: runtime-vulnerability-analysis
-            cg-devx.metadata.chart-version: 0.28.1
-            cg-devx.metadata.version: 0.28.1
+            cg-devx.metadata.chart-version: 0.33.2
+            cg-devx.metadata.version: 0.31.2
   syncPolicy:
     automated:
       prune: true

--- a/platform/gitops-pipelines/delivery/clusters/cc-cluster/core-services/components/harbor/harbor.yaml
+++ b/platform/gitops-pipelines/delivery/clusters/cc-cluster/core-services/components/harbor/harbor.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: harbor
     repoURL: https://helm.goharbor.io
-    targetRevision: v1.16.3
+    targetRevision: v1.19.1
     helm:
       releaseName: harbor
       values: |
@@ -42,8 +42,8 @@ spec:
               cg-devx.cost-allocation.cost-center: platform
               cg-devx.metadata.owner: <GITOPS_REPOSITORY_NAME>-admin
               cg-devx.metadata.service: oci-registry.harbor
-              cg-devx.metadata.chart-version: 1.16.3
-              cg-devx.metadata.version: 2.12.3
+              cg-devx.metadata.chart-version: 1.19.1
+              cg-devx.metadata.version: 2.15.1
         database:
           type: internal
           internal:
@@ -55,8 +55,8 @@ spec:
             cg-devx.cost-allocation.cost-center: platform
             cg-devx.metadata.owner: <GITOPS_REPOSITORY_NAME>-admin
             cg-devx.metadata.service: oci-registry.harbor
-            cg-devx.metadata.chart-version: 1.16.3
-            cg-devx.metadata.version: 2.12.3
+            cg-devx.metadata.chart-version: 1.19.1
+            cg-devx.metadata.version: 2.15.1
         registry:
           # set the service account to be used, default if left empty
           serviceAccountName: ""
@@ -75,8 +75,8 @@ spec:
             cg-devx.cost-allocation.cost-center: platform
             cg-devx.metadata.owner: <GITOPS_REPOSITORY_NAME>-admin
             cg-devx.metadata.service: oci-registry.harbor
-            cg-devx.metadata.chart-version: 1.16.3
-            cg-devx.metadata.version: 2.12.3
+            cg-devx.metadata.chart-version: 1.19.1
+            cg-devx.metadata.version: 2.15.1
         portal:
           resources:
             requests:
@@ -86,8 +86,8 @@ spec:
             cg-devx.cost-allocation.cost-center: platform
             cg-devx.metadata.owner: <GITOPS_REPOSITORY_NAME>-admin
             cg-devx.metadata.service: oci-registry.harbor
-            cg-devx.metadata.chart-version: 1.16.3
-            cg-devx.metadata.version: 2.12.3
+            cg-devx.metadata.chart-version: 1.19.1
+            cg-devx.metadata.version: 2.15.1
         persistence:
           enabled: true
           imageChartStorage:
@@ -106,8 +106,8 @@ spec:
             cg-devx.cost-allocation.cost-center: platform
             cg-devx.metadata.owner: <GITOPS_REPOSITORY_NAME>-admin
             cg-devx.metadata.service: oci-registry.harbor
-            cg-devx.metadata.chart-version: 1.16.3
-            cg-devx.metadata.version: 2.12.3
+            cg-devx.metadata.chart-version: 1.19.1
+            cg-devx.metadata.version: 2.15.1
         jobservice:
           resources:
             requests:
@@ -117,8 +117,8 @@ spec:
             cg-devx.cost-allocation.cost-center: platform
             cg-devx.metadata.owner: <GITOPS_REPOSITORY_NAME>-admin
             cg-devx.metadata.service: oci-registry.harbor
-            cg-devx.metadata.chart-version: 1.16.3
-            cg-devx.metadata.version: 2.12.3
+            cg-devx.metadata.chart-version: 1.19.1
+            cg-devx.metadata.version: 2.15.1
         redis:
           type: internal
           internal:
@@ -130,16 +130,16 @@ spec:
             cg-devx.cost-allocation.cost-center: platform
             cg-devx.metadata.owner: <GITOPS_REPOSITORY_NAME>-admin
             cg-devx.metadata.service: oci-registry.harbor
-            cg-devx.metadata.chart-version: 1.16.3
-            cg-devx.metadata.version: 2.12.3
+            cg-devx.metadata.chart-version: 1.19.1
+            cg-devx.metadata.version: 2.15.1
         notary:
           enabled: false
           podLabels:
             cg-devx.cost-allocation.cost-center: platform
             cg-devx.metadata.owner: <GITOPS_REPOSITORY_NAME>-admin
             cg-devx.metadata.service: oci-registry.harbor
-            cg-devx.metadata.chart-version: 1.16.3
-            cg-devx.metadata.version: 2.12.3
+            cg-devx.metadata.chart-version: 1.19.1
+            cg-devx.metadata.version: 2.15.1
         trivy:
           # enabled the flag to enable Trivy scanner
           enabled: true
@@ -147,8 +147,8 @@ spec:
             cg-devx.cost-allocation.cost-center: platform
             cg-devx.metadata.owner: <GITOPS_REPOSITORY_NAME>-admin
             cg-devx.metadata.service: oci-registry.harbor
-            cg-devx.metadata.chart-version: 1.16.3
-            cg-devx.metadata.version: 2.12.3
+            cg-devx.metadata.chart-version: 1.19.1
+            cg-devx.metadata.version: 2.15.1
         updateStrategy:
           type: Recreate
         existingSecretAdminPassword: harbor-admin

--- a/platform/gitops-pipelines/delivery/clusters/cc-cluster/core-services/components/kube-system/cert-manager/application.yaml
+++ b/platform/gitops-pipelines/delivery/clusters/cc-cluster/core-services/components/kube-system/cert-manager/application.yaml
@@ -9,7 +9,7 @@ spec:
   project: core
   source:
     repoURL: https://charts.jetstack.io
-    targetRevision: v1.17.2
+    targetRevision: v1.20.2
     helm:
       values: |-
         serviceAccount:
@@ -28,8 +28,8 @@ spec:
             cg-devx.cost-allocation.cost-center: platform
             cg-devx.metadata.owner: <GITOPS_REPOSITORY_NAME>-admin
             cg-devx.metadata.service: cert-manager
-            cg-devx.metadata.chart-version: 1.17.2
-            cg-devx.metadata.version: 1.17.2
+            cg-devx.metadata.chart-version: 1.20.2
+            cg-devx.metadata.version: v1.20.2
     chart: cert-manager
   destination:
     server: https://kubernetes.default.svc

--- a/platform/gitops-pipelines/delivery/clusters/cc-cluster/core-services/components/kube-system/external-dns/application.yaml
+++ b/platform/gitops-pipelines/delivery/clusters/cc-cluster/core-services/components/kube-system/external-dns/application.yaml
@@ -9,7 +9,7 @@ spec:
   project: core
   source:
     repoURL: https://kubernetes-sigs.github.io/external-dns
-    targetRevision: 1.16.1
+    targetRevision: 1.21.1
     helm:
       releaseName: external-dns
       values: |
@@ -24,8 +24,8 @@ spec:
           cg-devx.cost-allocation.cost-center: platform
           cg-devx.metadata.owner: <GITOPS_REPOSITORY_NAME>-admin
           cg-devx.metadata.service: external-dns
-          cg-devx.metadata.chart-version: 1.16.1
-          cg-devx.metadata.version: 0.16.1
+          cg-devx.metadata.chart-version: 1.21.1
+          cg-devx.metadata.version: 0.21.0
         # <EXTERNAL_DNS_ADDITIONAL_CONFIGURATION>
         domainFilters:
           - <CC_CLUSTER_FQDN>

--- a/platform/gitops-pipelines/delivery/clusters/cc-cluster/core-services/components/kube-system/external-secrets-operator/external-secrets-operator.yaml
+++ b/platform/gitops-pipelines/delivery/clusters/cc-cluster/core-services/components/kube-system/external-secrets-operator/external-secrets-operator.yaml
@@ -9,7 +9,7 @@ spec:
   project: core
   source:
     repoURL: https://charts.external-secrets.io
-    targetRevision: 0.16.0
+    targetRevision: 2.6.0
     helm:
       values: |-
         serviceAccount:
@@ -19,8 +19,8 @@ spec:
           cg-devx.cost-allocation.cost-center: platform
           cg-devx.metadata.owner: <GITOPS_REPOSITORY_NAME>-admin
           cg-devx.metadata.service: external-secrets-operator
-          cg-devx.metadata.chart-version: 0.16.0
-          cg-devx.metadata.version: 0.16.0
+          cg-devx.metadata.chart-version: 2.6.0
+          cg-devx.metadata.version: v2.6.0
     chart: external-secrets
   destination:
     server: https://kubernetes.default.svc

--- a/platform/gitops-pipelines/delivery/clusters/cc-cluster/core-services/components/kube-system/ingress-nginx/application.yaml
+++ b/platform/gitops-pipelines/delivery/clusters/cc-cluster/core-services/components/kube-system/ingress-nginx/application.yaml
@@ -11,7 +11,7 @@ spec:
   project: core
   source:
     repoURL: https://kubernetes.github.io/ingress-nginx
-    targetRevision: 4.12.2
+    targetRevision: 4.15.1
     helm:
       values: |-
         controller:
@@ -33,8 +33,8 @@ spec:
           cg-devx.cost-allocation.cost-center: platform
           cg-devx.metadata.owner: <GITOPS_REPOSITORY_NAME>-admin
           cg-devx.metadata.service: ingress-nginx
-          cg-devx.metadata.chart-version: 4.12.2
-          cg-devx.metadata.version: 1.12.2
+          cg-devx.metadata.chart-version: 4.15.1
+          cg-devx.metadata.version: 1.15.1
     chart: ingress-nginx
   destination:
     server: https://kubernetes.default.svc

--- a/platform/gitops-pipelines/delivery/clusters/cc-cluster/core-services/components/kube-system/reloader/application.yaml
+++ b/platform/gitops-pipelines/delivery/clusters/cc-cluster/core-services/components/kube-system/reloader/application.yaml
@@ -9,7 +9,7 @@ spec:
   project: core
   source:
     repoURL: 'https://stakater.github.io/stakater-charts'
-    targetRevision: v2.1.3
+    targetRevision: v2.2.12
     chart: reloader
     helm:
       values: |-
@@ -23,8 +23,8 @@ spec:
             cg-devx.cost-allocation.cost-center: platform
             cg-devx.metadata.owner: <GITOPS_REPOSITORY_NAME>-admin
             cg-devx.metadata.service: pod-reloader
-            cg-devx.metadata.chart-version: 2.1.3
-            cg-devx.metadata.version: 1.4.2
+            cg-devx.metadata.chart-version: 2.2.12
+            cg-devx.metadata.version: v1.4.17
   destination:
     server: 'https://kubernetes.default.svc'
     namespace: reloader

--- a/platform/gitops-pipelines/delivery/clusters/cc-cluster/core-services/components/kubecost/kubecost.yaml
+++ b/platform/gitops-pipelines/delivery/clusters/cc-cluster/core-services/components/kubecost/kubecost.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: cost-analyzer
     repoURL: https://kubecost.github.io/cost-analyzer/
-    targetRevision: 2.7.2
+    targetRevision: 2.8.6
     helm:
       releaseName: kubecost
       values: |
@@ -26,8 +26,8 @@ spec:
             cg-devx.cost-allocation.cost-center: platform
             cg-devx.metadata.owner: <GITOPS_REPOSITORY_NAME>-admin
             cg-devx.metadata.service: cost-management.kubecost
-            cg-devx.metadata.chart-version: 2.7.2
-            cg-devx.metadata.version: 2.7.2
+            cg-devx.metadata.chart-version: 2.8.6
+            cg-devx.metadata.version: 2.8.6
           prometheus:
             enabled: false
             fqdn: http://kube-prometheus-stack-prometheus.monitoring.svc.cluster.local:9090

--- a/platform/gitops-pipelines/delivery/clusters/cc-cluster/core-services/components/loki/loki.yaml
+++ b/platform/gitops-pipelines/delivery/clusters/cc-cluster/core-services/components/loki/loki.yaml
@@ -47,8 +47,8 @@ spec:
             cg-devx.cost-allocation.cost-center: platform
             cg-devx.metadata.owner: <GITOPS_REPOSITORY_NAME>-admin
             cg-devx.metadata.service: log-management.loki
-            cg-devx.metadata.chart-version: 6.30.0
-            cg-devx.metadata.version: 3.5.0
+            cg-devx.metadata.chart-version: 7.0.0
+            cg-devx.metadata.version: 3.6.7
         test:
           enabled: false
         lokiCanary:
@@ -99,7 +99,7 @@ spec:
                       summary: >-
                         {{ printf "Service {{ $labels.namespace }}, Pod {{ $labels.pod }} has being force terminated and is attempting to recover." }}
     repoURL: https://grafana.github.io/helm-charts
-    targetRevision: 6.30.0
+    targetRevision: 7.0.0
   syncPolicy:
     automated:
       prune: true

--- a/platform/gitops-pipelines/delivery/clusters/cc-cluster/core-services/components/ml-services/gpu-operator/application.yaml
+++ b/platform/gitops-pipelines/delivery/clusters/cc-cluster/core-services/components/ml-services/gpu-operator/application.yaml
@@ -10,7 +10,7 @@ spec:
   source:
     repoURL: https://helm.ngc.nvidia.com/nvidia
     chart: gpu-operator
-    targetRevision: v24.3.0
+    targetRevision: v26.3.2
     helm:
       values: |-
         daemonsets:
@@ -18,8 +18,8 @@ spec:
             cg-devx.cost-allocation.cost-center: platform
             cg-devx.metadata.owner: <GITOPS_REPOSITORY_NAME>-admin
             cg-devx.metadata.service: ml.gpu-operator
-            cg-devx.metadata.chart-version: 24.3.0
-            cg-devx.metadata.version: 24.3.0
+            cg-devx.metadata.chart-version: 26.3.2
+            cg-devx.metadata.version: v26.3.2
       parameters:
         # set tolerations to work on gpu enabled node groups
         # node-feature-discovery.worker

--- a/platform/gitops-pipelines/delivery/clusters/cc-cluster/core-services/components/monitoring/kube-prometheus-stack.yaml
+++ b/platform/gitops-pipelines/delivery/clusters/cc-cluster/core-services/components/monitoring/kube-prometheus-stack.yaml
@@ -24,8 +24,8 @@ spec:
           cg-devx.cost-allocation.cost-center: platform
           cg-devx.metadata.owner: <GITOPS_REPOSITORY_NAME>-admin
           cg-devx.metadata.service: observability.prometheus-stack
-          cg-devx.metadata.chart-version: 72.6.2
-          cg-devx.metadata.version: 0.82.2
+          cg-devx.metadata.chart-version: 87.1.0
+          cg-devx.metadata.version: v0.92.0
         prometheus:
           prometheusSpec:
             podMonitorSelectorNilUsesHelmValues: false
@@ -197,7 +197,7 @@ spec:
               k8s-scaler-keda:
                 url: https://raw.githubusercontent.com/kedacore/keda/main/config/grafana/keda-dashboard.json
     repoURL: https://prometheus-community.github.io/helm-charts
-    targetRevision: 72.6.2
+    targetRevision: 87.1.0
   syncPolicy:
     automated:
       prune: true

--- a/platform/gitops-pipelines/delivery/clusters/cc-cluster/core-services/components/monitoringcrd/prometheus-operator-crds.yaml
+++ b/platform/gitops-pipelines/delivery/clusters/cc-cluster/core-services/components/monitoringcrd/prometheus-operator-crds.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: prometheus-operator-crds
     repoURL: https://prometheus-community.github.io/helm-charts
-    targetRevision: 20.0.0
+    targetRevision: 30.0.0
   syncPolicy:
     automated:
       prune: true

--- a/platform/gitops-pipelines/delivery/clusters/cc-cluster/core-services/components/perfectscale/application.yaml
+++ b/platform/gitops-pipelines/delivery/clusters/cc-cluster/core-services/components/perfectscale/application.yaml
@@ -11,7 +11,7 @@ spec:
   source:
     repoURL: https://perfectscale-io.github.io
     chart: exporter
-    targetRevision: v1.0.41
+    targetRevision: v1.1.11
     helm:
       values: |-
         secret:
@@ -22,7 +22,7 @@ spec:
           cg-devx.cost-allocation.cost-center: platform
           cg-devx.metadata.owner: <GITOPS_REPOSITORY_NAME>-admin
           cg-devx.metadata.service: scaler.perfectscale
-          cg-devx.metadata.chart-version: 1.0.41
+          cg-devx.metadata.chart-version: 1.1.11
           cg-devx.metadata.version: 1.0.0
   destination:
     server: 'https://kubernetes.default.svc'
@@ -46,7 +46,7 @@ spec:
   source:
     repoURL: https://perfectscale-io.github.io
     chart: psc-autoscaler
-    targetRevision: v1.0.10
+    targetRevision: v1.0.49
     helm:
       values: |-
         secret:

--- a/platform/gitops-pipelines/delivery/clusters/cc-cluster/core-services/components/promtail/promtail.yaml
+++ b/platform/gitops-pipelines/delivery/clusters/cc-cluster/core-services/components/promtail/promtail.yaml
@@ -50,9 +50,9 @@ spec:
             cg-devx.metadata.owner: <GITOPS_REPOSITORY_NAME>-admin
             cg-devx.metadata.service: log-management.promtail
             cg-devx.metadata.chart-version: 0.20.2
-            cg-devx.metadata.version: 0.25.2
+            cg-devx.metadata.version: 3.5.1
     repoURL: https://grafana.github.io/helm-charts
-    targetRevision: 6.16.6
+    targetRevision: 6.17.1
   syncPolicy:
     automated:
       prune: true

--- a/platform/gitops-pipelines/delivery/clusters/cc-cluster/core-services/components/runners/gitlab/gitlab-runner/application.yaml
+++ b/platform/gitops-pipelines/delivery/clusters/cc-cluster/core-services/components/runners/gitlab/gitlab-runner/application.yaml
@@ -14,7 +14,7 @@ spec:
   project: default
   source:
     repoURL: 'https://charts.gitlab.io'
-    targetRevision: 0.77.2
+    targetRevision: 0.90.0
     helm:
       values: |-
         gitlabUrl: https://gitlab.com
@@ -43,14 +43,14 @@ spec:
           cg-devx.cost-allocation.cost-center: platform
           cg-devx.metadata.owner: <GITOPS_REPOSITORY_NAME>-admin
           cg-devx.metadata.service: vsc.runner
-          cg-devx.metadata.chart-version: 0.77.2
-          cg-devx.metadata.version: 0.27.6
+          cg-devx.metadata.chart-version: 0.90.0
+          cg-devx.metadata.version: 19.1.0
         podLabels:
           cg-devx.cost-allocation.cost-center: platform
           cg-devx.metadata.owner: <GITOPS_REPOSITORY_NAME>-admin
           cg-devx.metadata.service: vsc.runner
-          cg-devx.metadata.chart-version: 0.77.2
-          cg-devx.metadata.version: 0.27.6    
+          cg-devx.metadata.chart-version: 0.90.0
+          cg-devx.metadata.version: 19.1.0    
     chart: gitlab-runner
   syncPolicy:
     automated:

--- a/platform/gitops-pipelines/delivery/clusters/cc-cluster/core-services/components/scalers/cluster-autoscaler/application.yaml
+++ b/platform/gitops-pipelines/delivery/clusters/cc-cluster/core-services/components/scalers/cluster-autoscaler/application.yaml
@@ -10,7 +10,7 @@ spec:
   source:
     repoURL: https://kubernetes.github.io/autoscaler
     chart: cluster-autoscaler
-    targetRevision: 9.46.6
+    targetRevision: 9.58.0
     helm:
       values: |-
         affinity: {}
@@ -21,8 +21,8 @@ spec:
           cg-devx.cost-allocation.cost-center: platform
           cg-devx.metadata.owner: <GITOPS_REPOSITORY_NAME>-admin
           cg-devx.metadata.service: scaler.cluster-autoscaler
-          cg-devx.metadata.chart-version: 9.46.6
-          cg-devx.metadata.version: 1.32.0
+          cg-devx.metadata.chart-version: 9.58.0
+          cg-devx.metadata.version: 1.35.0
         autoDiscovery:
           clusterName: <PRIMARY_CLUSTER_NAME>
           tags:

--- a/platform/gitops-pipelines/delivery/clusters/cc-cluster/core-services/components/scalers/keda/application.yaml
+++ b/platform/gitops-pipelines/delivery/clusters/cc-cluster/core-services/components/scalers/keda/application.yaml
@@ -10,7 +10,7 @@ spec:
   source:
     repoURL: https://kedacore.github.io/charts
     chart: keda
-    targetRevision: v2.17.1
+    targetRevision: v2.20.1
     helm:
       values: |-
         clusterName: <PRIMARY_CLUSTER_NAME>
@@ -20,8 +20,8 @@ spec:
           cg-devx.cost-allocation.cost-center: platform
           cg-devx.metadata.owner: <GITOPS_REPOSITORY_NAME>-admin
           cg-devx.metadata.service: scaler.keda
-          cg-devx.metadata.chart-version: 2.17.1
-          cg-devx.metadata.version: 2.17.1
+          cg-devx.metadata.chart-version: 2.20.1
+          cg-devx.metadata.version: 2.20.1
         crds:
           additionalAnnotations:
             argocd.argoproj.io/sync-options: ServerSideApply=true

--- a/platform/gitops-pipelines/delivery/clusters/cc-cluster/core-services/components/sonarqube/sonarqube.yaml
+++ b/platform/gitops-pipelines/delivery/clusters/cc-cluster/core-services/components/sonarqube/sonarqube.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: sonarqube
     repoURL: https://SonarSource.github.io/helm-chart-sonarqube
-    targetRevision: 10.2.0
+    targetRevision: 10.8.1
     helm:
       releaseName: sonarqube
       values: |
@@ -49,8 +49,8 @@ spec:
             cg-devx.cost-allocation.cost-center: platform
             cg-devx.metadata.owner: <GITOPS_REPOSITORY_NAME>-admin
             cg-devx.metadata.service: code-quality.sonarqube
-            cg-devx.metadata.chart-version: 10.2.0
-            cg-devx.metadata.version: 10.2.0
+            cg-devx.metadata.chart-version: 10.8.1
+            cg-devx.metadata.version: 10.8.1
           tls:
             - secretName: sonarqube-tls
               hosts:
@@ -61,8 +61,8 @@ spec:
           cg-devx.cost-allocation.cost-center: platform
           cg-devx.metadata.owner: <GITOPS_REPOSITORY_NAME>-admin
           cg-devx.metadata.service: code-quality.sonarqube
-          cg-devx.metadata.chart-version: 10.2.0
-          cg-devx.metadata.version: 10.2.0
+          cg-devx.metadata.chart-version: 10.8.1
+          cg-devx.metadata.version: 10.8.1
   syncPolicy:
     automated:
       prune: true

--- a/platform/gitops-pipelines/delivery/clusters/cc-cluster/core-services/components/vault/application.yaml
+++ b/platform/gitops-pipelines/delivery/clusters/cc-cluster/core-services/components/vault/application.yaml
@@ -9,7 +9,7 @@ spec:
   project: core
   source:
     repoURL: https://helm.releases.hashicorp.com
-    targetRevision: 0.26.1
+    targetRevision: 0.33.0
     helm:
       parameters:
         - name: server.route.host
@@ -25,8 +25,8 @@ spec:
             cg-devx.cost-allocation.cost-center: platform
             cg-devx.metadata.owner: <GITOPS_REPOSITORY_NAME>-admin
             cg-devx.metadata.service: secrets-management.hashicorp-vault
-            cg-devx.metadata.chart-version: 0.26.1
-            cg-devx.metadata.version: 1.15.1
+            cg-devx.metadata.chart-version: 0.33.0
+            cg-devx.metadata.version: 2.0.2
             # <ADDITIONAL_LABELS>
           serviceAccount:
             create: true

--- a/platform/gitops-pipelines/delivery/clusters/cc-cluster/core-services/components/velero/core/velero.yaml
+++ b/platform/gitops-pipelines/delivery/clusters/cc-cluster/core-services/components/velero/core/velero.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: velero
     repoURL: https://vmware-tanzu.github.io/helm-charts
-    targetRevision: 7.2.1
+    targetRevision: 12.0.3
     helm:
       releaseName: velero
       values: |

--- a/platform/installation-manifests/argocd/kustomization.yaml
+++ b/platform/installation-manifests/argocd/kustomization.yaml
@@ -5,7 +5,7 @@ namespace: argocd
 # To upgrade ArgoCD, increment the version here
 # https://github.com/argoproj/argo-cd/tags
 resources:
-  - github.com:argoproj/argo-cd.git/manifests/ha/cluster-install?ref=v2.14.12
+  - github.com:argoproj/argo-cd.git/manifests/ha/cluster-install?ref=v3.4.4
   - argocd-namespace.yaml
 
 patches:


### PR DESCRIPTION
Bumps 28 chart `targetRevision`s (+ metadata labels) to latest stable and ArgoCD v2.14.12→v3.4.4. CRD/operator pairs kept in lockstep (prometheus-operator-crds 30 ↔ kube-prometheus-stack 87; kyverno ↔ kyverno-policies 3.8).

Verified: 29/29 charts render via `helm template` with their inline values; ArgoCD `kubectl kustomize` builds (71 resources).

Notable: external-secrets 0.16→2.6, vault 0.26→0.33, velero 7→12, loki 6→7, harbor 1.16→1.19, cert-manager 1.17→1.20, backstage 1.6→2.8 (removed `image.debug`).
Held to latest patch of current line: kubecost 2.8.6 (2.9 is a non-rendering upgrade-bridge), sonarqube 10.8.1 (2026 line is a product-major + plugin break).

⚠️ `helm template` can't catch value keys silently dropped across majors — review each app's upgrade notes via the ArgoCD diff before sync.