### PR TITLE
deps(images): pin floating :latest image tags

### DIFF
--- a/platform/gitops-pipelines/delivery/clusters/cc-cluster/core-services/components/oauth2-proxy/oauth2-proxy.yaml
+++ b/platform/gitops-pipelines/delivery/clusters/cc-cluster/core-services/components/oauth2-proxy/oauth2-proxy.yaml
@@ -37,7 +37,7 @@ spec:
               secretKeyRef:
                 name: oauth2-proxy-secrets
                 key: cookie-secret
-        image: quay.io/oauth2-proxy/oauth2-proxy:latest
+        image: quay.io/oauth2-proxy/oauth2-proxy:v7.15.3
         imagePullPolicy: Always
         name: oauth2-proxy
         ports:

--- a/platform/gitops-pipelines/delivery/clusters/cc-cluster/core-services/components/runners/github/actions-runner-controller/application.yaml
+++ b/platform/gitops-pipelines/delivery/clusters/cc-cluster/core-services/components/runners/github/actions-runner-controller/application.yaml
@@ -33,7 +33,7 @@ spec:
         dockerRegistryMirror: ""
         image:
           repository: "summerwind/actions-runner-controller"
-          actionsRunnerRepositoryAndTag: "summerwind/actions-runner:latest"
+          actionsRunnerRepositoryAndTag: "summerwind/actions-runner:v2.335.1-ubuntu-24.04"
           dindSidecarRepositoryAndTag: "docker:dind"
           pullPolicy: IfNotPresent
           # The default image-pull secrets name for self-hosted runner container.

--- a/platform/gitops-pipelines/delivery/clusters/cc-cluster/core-services/components/velero/core/wait.yaml
+++ b/platform/gitops-pipelines/delivery/clusters/cc-cluster/core-services/components/velero/core/wait.yaml
@@ -41,7 +41,7 @@ spec:
       serviceAccountName: k8s-toolkit-velero-wait
       containers:
         - name: wait
-          image: registry.hub.docker.com/bitnami/kubectl:latest
+          image: rancher/kubectl:v1.33.12
           imagePullPolicy: IfNotPresent
           args:
             - "rollout"


### PR DESCRIPTION
Pins the 3 images that used `:latest` for reproducible deploys:
- oauth2-proxy → v7.15.3
- ARC runner → v2.335.1-ubuntu-24.04
- velero wait Job → rancher/kubectl:v1.33.12 (bitnami's free Docker Hub kubectl tags now 404; switched to the maintained image at the 1.33 line)