### PR TITLE
deps(ci): bump GitHub Actions & add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+version: 2
+updates:
+  # Python CLI (Poetry)
+  - package-ecosystem: "pip"
+    directory: "/tools"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+
+  # GitHub Actions used by the release workflows
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+
+  # Terraform providers and modules
+  - package-ecosystem: "terraform"
+    directories:
+      - "/platform/terraform/*"
+      - "/platform/terraform/modules/*"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10

--- a/.github/workflows/pre_release.yml
+++ b/.github/workflows/pre_release.yml
@@ -5,11 +5,11 @@ on:
       PYTHON_VERSION:
         description: "Python Version"
         required: false
-        default: "3.12.2"  
+        default: "3.12"  
       POETRY_VERSION:
         description: "The version of Poetry to use"
         required: false
-        default: "1.8.2"  # Ensure this matches the latest stable version
+        default: "2.4.1"  # Ensure this matches the latest stable version
       RELEASE_TAG:
         description: "The new version should be a valid PEP 440 string"
         required: true
@@ -21,12 +21,12 @@ jobs:
   test_pypi_release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
       - name: Install Poetry
         run: pip install poetry==${{ inputs.POETRY_VERSION }}
         shell: bash
       - name: Set up Python ${{ inputs.PYTHON_VERSION }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ inputs.PYTHON_VERSION }}
       - name: Configure Poetry with specified Python version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,11 +5,11 @@ on:
       PYTHON_VERSION:
         description: "Python Version"
         required: false
-        default: "3.12.2"
+        default: "3.12"
       POETRY_VERSION:
         description: "The version of Poetry to use"
         required: false
-        default: "1.8.2"
+        default: "2.4.1"
       RELEASE_TAG:
         description: "The new version should be a valid PEP 440 string"
         required: true
@@ -22,12 +22,12 @@ jobs:
     name: Builds Using Poetry and Publishes to PyPI
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
       - name: Install Poetry
         run: pip install poetry==${{ inputs.POETRY_VERSION }}
         shell: bash
       - name: Set up Python ${{ inputs.PYTHON_VERSION }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ inputs.PYTHON_VERSION }}
       - run: poetry version ${{ inputs.RELEASE_TAG }}


### PR DESCRIPTION
- actions/checkout v3→v7, actions/setup-python v4→v6 (ncipollo/release-action already on latest major v1)
- workflow input defaults: Python 3.12.2→3.12, Poetry 1.8.2→2.4.1
- add `.github/dependabot.yml` (pip, github-actions, terraform; weekly) so deps don't fall behind again